### PR TITLE
feat: add request package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require github.com/stretchr/testify v1.7.0
 
 require (
-	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/x/request/doc.go
+++ b/x/request/doc.go
@@ -1,0 +1,7 @@
+// Package request exposes types and helper methods to create, add, and retrieve
+// request-scoped attributes to context.Context.
+//
+// Request-scoped attributes include identifiers like the request and correlation
+// IDs. When the request is authenticated, user identifiers like the account and
+// user aggregate IDs can also be added to the context.
+package request

--- a/x/request/requestids.go
+++ b/x/request/requestids.go
@@ -12,17 +12,22 @@ type RequestIDs struct {
 	CorrelationID string
 }
 
-// AddRequestIDsToContext returns a new context with the given RequestIDs
+// ContextWithRequestIDs returns a new context with the given RequestIDs
 // embedded as a value.
 func ContextWithRequestIDs(ctx context.Context, fields RequestIDs) context.Context {
 	return context.WithValue(ctx, requestIDsKey, fields)
 }
 
+// RequestIDsFromContext attempts to retrieve a RequestIDs struct from the given
+// context, returning a RequestIDs struct along with a boolean signalling
+// whether the retrieval was successful.
 func RequestIDsFromContext(ctx context.Context) (RequestIDs, bool) {
 	ids, ok := ctx.Value(requestIDsKey).(RequestIDs)
 	return ids, ok
 }
 
+// ContextHasRequestIDs returns whether the given context contains a RequestIDs
+// value.
 func ContextHasRequestIDs(ctx context.Context) bool {
 	_, ok := RequestIDsFromContext(ctx)
 	return ok

--- a/x/request/requestids.go
+++ b/x/request/requestids.go
@@ -1,0 +1,29 @@
+package request
+
+import "context"
+
+type contextValueKey string
+
+const requestIDsKey = contextValueKey("fields")
+
+// RequestIDs represent the set of unique identifiers for a request.
+type RequestIDs struct {
+	RequestID     string
+	CorrelationID string
+}
+
+// AddRequestIDsToContext returns a new context with the given RequestIDs
+// embedded as a value.
+func ContextWithRequestIDs(ctx context.Context, fields RequestIDs) context.Context {
+	return context.WithValue(ctx, requestIDsKey, fields)
+}
+
+func RequestIDsFromContext(ctx context.Context) (RequestIDs, bool) {
+	ids, ok := ctx.Value(requestIDsKey).(RequestIDs)
+	return ids, ok
+}
+
+func ContextHasRequestIDs(ctx context.Context) bool {
+	_, ok := RequestIDsFromContext(ctx)
+	return ok
+}

--- a/x/request/requestids_test.go
+++ b/x/request/requestids_test.go
@@ -2,6 +2,7 @@ package request_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cultureamp/ca-go/x/request"
@@ -26,11 +27,44 @@ func TestContextWithRequestIDs(t *testing.T) {
 	assert.True(t, ok)
 }
 
+func ExampleContextWithRequestIDs() {
+	requestIDs := request.RequestIDs{
+		RequestID:     "123",
+		CorrelationID: "456",
+	}
+	ctx := context.Background()
+
+	ctx = request.ContextWithRequestIDs(ctx, requestIDs)
+
+	if requestIDsFromContext, ok := request.RequestIDsFromContext(ctx); ok {
+		fmt.Println(requestIDsFromContext.RequestID)
+		fmt.Println(requestIDsFromContext.CorrelationID)
+
+		// Output:
+		// 123
+		// 456
+	}
+}
+
 func TestRequestIDsFromContextMissing(t *testing.T) {
 	ctx := context.Background()
 
 	_, ok := request.RequestIDsFromContext(ctx)
 	assert.False(t, ok)
+}
+
+func ExampleContextHasRequestIDs() {
+	requestIDs := request.RequestIDs{
+		RequestID:     "123",
+		CorrelationID: "456",
+	}
+	ctx := context.Background()
+
+	ctx = request.ContextWithRequestIDs(ctx, requestIDs)
+
+	ok := request.ContextHasRequestIDs(ctx)
+	fmt.Println(ok)
+	// Output: true
 }
 
 func TestContextHasRequestIDsSucceeds(t *testing.T) {

--- a/x/request/requestids_test.go
+++ b/x/request/requestids_test.go
@@ -1,0 +1,48 @@
+package request_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cultureamp/ca-go/x/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func newRequestIDs() request.RequestIDs {
+	return request.RequestIDs{
+		RequestID:     "123",
+		CorrelationID: "456",
+	}
+}
+
+func TestContextWithRequestIDs(t *testing.T) {
+	ids := newRequestIDs()
+	ctx := context.Background()
+
+	ctx = request.ContextWithRequestIDs(ctx, ids)
+	idsFromContext, ok := request.RequestIDsFromContext(ctx)
+
+	assert.Equal(t, ids, idsFromContext)
+	assert.True(t, ok)
+}
+
+func TestRequestIDsFromContextMissing(t *testing.T) {
+	ctx := context.Background()
+
+	_, ok := request.RequestIDsFromContext(ctx)
+	assert.False(t, ok)
+}
+
+func TestContextHasRequestIDsSucceeds(t *testing.T) {
+	ctx := request.ContextWithRequestIDs(context.Background(), newRequestIDs())
+
+	ok := request.ContextHasRequestIDs(ctx)
+	assert.True(t, ok)
+}
+
+func TestContextHasRequestIDsFails(t *testing.T) {
+	ctx := context.Background()
+
+	ok := request.ContextHasRequestIDs(ctx)
+	assert.False(t, ok)
+}

--- a/x/request/user.go
+++ b/x/request/user.go
@@ -4,6 +4,8 @@ import "context"
 
 const authenticatedUserKey = contextValueKey("authenticatedUser")
 
+// AuthenticatedUser holds the identifiers of a user making an authenticated
+// request.
 type AuthenticatedUser struct {
 	// CustomerAccountID is the ID of the currently logged in user's parent
 	// account/organization, sometimes known as the "account_aggregate_id".
@@ -16,11 +18,16 @@ type AuthenticatedUser struct {
 	RealUserID string
 }
 
+// ContextWithAuthenticatedUser returns a new context with the given user
+// embedded as a value.
 func ContextWithAuthenticatedUser(parent context.Context, user AuthenticatedUser) context.Context {
 	ctx := context.WithValue(parent, authenticatedUserKey, user)
 	return ctx
 }
 
+// AuthenticatedUserFromContext attempts to retrieve an AuthenticatedUser
+// from the given context, returning an AuthenticatedUser along with a boolean
+// signalling whether the retrieval was successful.
 func AuthenticatedUserFromContext(ctx context.Context) (AuthenticatedUser, bool) {
 	value := ctx.Value(authenticatedUserKey)
 
@@ -28,6 +35,8 @@ func AuthenticatedUserFromContext(ctx context.Context) (AuthenticatedUser, bool)
 	return user, ok
 }
 
+// ContextHasAuthenticatedUser returns whether the given context contains
+// an AuthenticatedUser value.
 func ContextHasAuthenticatedUser(ctx context.Context) bool {
 	_, ok := AuthenticatedUserFromContext(ctx)
 	return ok

--- a/x/request/user.go
+++ b/x/request/user.go
@@ -1,0 +1,34 @@
+package request
+
+import "context"
+
+const authenticatedUserKey = contextValueKey("authenticatedUser")
+
+type AuthenticatedUser struct {
+	// CustomerAccountID is the ID of the currently logged in user's parent
+	// account/organization, sometimes known as the "account_aggregate_id".
+	CustomerAccountID string
+	// UserID is the ID of the currently authenticated user, and will
+	// generally be a "user_aggregate_id".
+	UserID string
+	// RealUserID, when supplied, is the ID of the user who is currently
+	// impersonating the current "UserID". This value is optional.
+	RealUserID string
+}
+
+func ContextWithAuthenticatedUser(parent context.Context, user AuthenticatedUser) context.Context {
+	ctx := context.WithValue(parent, authenticatedUserKey, user)
+	return ctx
+}
+
+func AuthenticatedUserFromContext(ctx context.Context) (AuthenticatedUser, bool) {
+	value := ctx.Value(authenticatedUserKey)
+
+	user, ok := value.(AuthenticatedUser)
+	return user, ok
+}
+
+func ContextHasAuthenticatedUser(ctx context.Context) bool {
+	_, ok := AuthenticatedUserFromContext(ctx)
+	return ok
+}

--- a/x/request/user_test.go
+++ b/x/request/user_test.go
@@ -1,0 +1,72 @@
+package request_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cultureamp/ca-go/x/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func newAuthenticatedUser() request.AuthenticatedUser {
+	return request.AuthenticatedUser{
+		CustomerAccountID: "123",
+		UserID:            "456",
+		RealUserID:        "789",
+	}
+}
+
+func TestContextWithAuthenticatedUser(t *testing.T) {
+	user := newAuthenticatedUser()
+	ctx := context.Background()
+
+	ctx = request.ContextWithAuthenticatedUser(ctx, user)
+	userFromContext, ok := request.AuthenticatedUserFromContext(ctx)
+
+	assert.Equal(t, user, userFromContext)
+	assert.True(t, ok)
+}
+
+func ExampleContextWithAuthenticatedUser() {
+	authenticatedUser := request.AuthenticatedUser{
+		CustomerAccountID: "123",
+		UserID:            "456",
+		RealUserID:        "789",
+	}
+	ctx := context.Background()
+
+	ctx = request.ContextWithAuthenticatedUser(ctx, authenticatedUser)
+
+	if authenticatedUserFromContext, ok := request.AuthenticatedUserFromContext(ctx); ok {
+		fmt.Println(authenticatedUserFromContext.CustomerAccountID)
+		fmt.Println(authenticatedUserFromContext.UserID)
+		fmt.Println(authenticatedUserFromContext.RealUserID)
+
+		// Output:
+		// 123
+		// 456
+		// 789
+	}
+}
+
+func TestAuthenticatedUserFromContextMissing(t *testing.T) {
+	ctx := context.Background()
+
+	_, ok := request.AuthenticatedUserFromContext(ctx)
+	assert.False(t, ok)
+}
+
+func TestContextHasAuthenticatedUserSuceeds(t *testing.T) {
+	ctx := request.ContextWithAuthenticatedUser(context.Background(), newAuthenticatedUser())
+
+	ok := request.ContextHasAuthenticatedUser(ctx)
+	assert.True(t, ok)
+}
+
+func TestContextHasAuthenticatedUserFails(t *testing.T) {
+	ctx := context.Background()
+
+	ok := request.ContextHasAuthenticatedUser(ctx)
+	assert.False(t, ok)
+}

--- a/x/request/user_test.go
+++ b/x/request/user_test.go
@@ -57,6 +57,22 @@ func TestAuthenticatedUserFromContextMissing(t *testing.T) {
 	assert.False(t, ok)
 }
 
+func ExampleContextHasAuthenticatedUser() {
+	authenticatedUser := request.AuthenticatedUser{
+		CustomerAccountID: "123",
+		UserID:            "456",
+		RealUserID:        "789",
+	}
+	ctx := context.Background()
+
+	ctx = request.ContextWithAuthenticatedUser(ctx, authenticatedUser)
+
+	ok := request.ContextHasAuthenticatedUser(ctx)
+	fmt.Println(ok)
+
+	// Output: true
+}
+
 func TestContextHasAuthenticatedUserSuceeds(t *testing.T) {
 	ctx := request.ContextWithAuthenticatedUser(context.Background(), newAuthenticatedUser())
 


### PR DESCRIPTION
This PR adds a `request` package exposing types and helper functions to create, add, and retrieve request-scoped attributes to context.Context.

There are two sets of attributes that can be unique per request:

- Request identifiers like the trace, correlation, and request IDs.
- User identifiers like their account and user IDs, for authenticated requests.

Both sets may need to be present in the context for certain request middleware to function correctly. An example is the Sentry error reporter, which is provided request and user identifiers where available.