### PR TITLE
feat: add support for querying product toggles

### DIFF
--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -126,6 +126,25 @@ func (c *Client) QueryIntWithEvaluationContext(key FlagName, evalContext evaluat
 	return c.wrappedClient.IntVariation(string(key), evalContext.ToLDFlagUser(), fallbackValue)
 }
 
+// QueryToggle retrieves the value of a boolean product toggle. The account is
+// extracted from the context. The supplied fallback value is always reflected in
+// the returned value regardless of whether an error occurs.
+func (c *Client) QueryToggle(ctx context.Context, key FlagName, fallbackValue bool) (bool, error) {
+	user, err := evaluationcontext.AccountFromContext(ctx)
+	if err != nil {
+		return fallbackValue, fmt.Errorf("get account from context: %w", err)
+	}
+
+	return c.wrappedClient.BoolVariation(string(key), user.ToLDToggleUser(), fallbackValue)
+}
+
+// QueryToggleWithEvaluationContext retrieves the value of a boolean product toggle. An
+// evaluation context must be supplied manually. The supplied fallback value is always
+// reflected in the returned value regardless of whether an error occurs.
+func (c *Client) QueryToggleWithEvaluationContext(key FlagName, evalContext evaluationcontext.ToggleContext, fallbackValue bool) (bool, error) {
+	return c.wrappedClient.BoolVariation(string(key), evalContext.ToLDToggleUser(), fallbackValue)
+}
+
 // RawClient returns the wrapped LaunchDarkly client. The return value should be
 // casted to an *ld.LDClient instance.
 func (c *Client) RawClient() interface{} {

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -78,14 +78,14 @@ func (c *Client) QueryBool(ctx context.Context, key FlagName, fallbackValue bool
 		return fallbackValue, fmt.Errorf("get user from context: %w", err)
 	}
 
-	return c.wrappedClient.BoolVariation(string(key), user.ToLDUser(), fallbackValue)
+	return c.wrappedClient.BoolVariation(string(key), user.ToLDFlagUser(), fallbackValue)
 }
 
 // QueryBoolWithEvaluationContext retrieves the value of a boolean flag. An evaluation context
 // must be supplied manually. The supplied fallback value is always reflected in the
 // returned value regardless of whether an error occurs.
-func (c *Client) QueryBoolWithEvaluationContext(key FlagName, evalContext evaluationcontext.Context, fallbackValue bool) (bool, error) {
-	return c.wrappedClient.BoolVariation(string(key), evalContext.ToLDUser(), fallbackValue)
+func (c *Client) QueryBoolWithEvaluationContext(key FlagName, evalContext evaluationcontext.FlagContext, fallbackValue bool) (bool, error) {
+	return c.wrappedClient.BoolVariation(string(key), evalContext.ToLDFlagUser(), fallbackValue)
 }
 
 // QueryString retrieves the value of a string flag. User attributes are
@@ -97,14 +97,14 @@ func (c *Client) QueryString(ctx context.Context, key FlagName, fallbackValue st
 		return fallbackValue, fmt.Errorf("get user from context: %w", err)
 	}
 
-	return c.wrappedClient.StringVariation(string(key), user.ToLDUser(), fallbackValue)
+	return c.wrappedClient.StringVariation(string(key), user.ToLDFlagUser(), fallbackValue)
 }
 
 // QueryStringWithEvaluationContext retrieves the value of a string flag. An evaluation context
 // must be supplied manually. The supplied fallback value is always reflected in the
 // returned value regardless of whether an error occurs.
-func (c *Client) QueryStringWithEvaluationContext(key FlagName, evalContext evaluationcontext.Context, fallbackValue string) (string, error) {
-	return c.wrappedClient.StringVariation(string(key), evalContext.ToLDUser(), fallbackValue)
+func (c *Client) QueryStringWithEvaluationContext(key FlagName, evalContext evaluationcontext.FlagContext, fallbackValue string) (string, error) {
+	return c.wrappedClient.StringVariation(string(key), evalContext.ToLDFlagUser(), fallbackValue)
 }
 
 // QueryInt retrieves the value of an integer flag. User attributes are
@@ -116,14 +116,14 @@ func (c *Client) QueryInt(ctx context.Context, key FlagName, fallbackValue int) 
 		return fallbackValue, fmt.Errorf("get user from context: %w", err)
 	}
 
-	return c.wrappedClient.IntVariation(string(key), user.ToLDUser(), fallbackValue)
+	return c.wrappedClient.IntVariation(string(key), user.ToLDFlagUser(), fallbackValue)
 }
 
 // QueryIntWithEvaluationContext retrieves the value of an integer flag. An evaluation context
 // must be supplied manually. The supplied fallback value is always reflected in the
 // returned value regardless of whether an error occurs.
-func (c *Client) QueryIntWithEvaluationContext(key FlagName, evalContext evaluationcontext.Context, fallbackValue int) (int, error) {
-	return c.wrappedClient.IntVariation(string(key), evalContext.ToLDUser(), fallbackValue)
+func (c *Client) QueryIntWithEvaluationContext(key FlagName, evalContext evaluationcontext.FlagContext, fallbackValue int) (int, error) {
+	return c.wrappedClient.IntVariation(string(key), evalContext.ToLDFlagUser(), fallbackValue)
 }
 
 // RawClient returns the wrapped LaunchDarkly client. The return value should be

--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -1,6 +1,6 @@
-// Package flags provides access to feature flags. It wraps the LaunchDarkly SDK
-// to expose a convenient and consistent way of configuring and using the
-// client.
+// Package flags provides access to feature flags and product toggles. It wraps
+// the LaunchDarkly SDK and exposes a convenient and consistent way of configuring
+// and using the client.
 //
 // The client can be configured and used as a managed singleton or as an
 // instance returned from a constructor function. The managed singleton provides
@@ -17,16 +17,16 @@
 //
 //   err = flags.Connect()
 //   if err != nil {
-//	   // handle errors connecting to LaunchDarkly
-//	 }
+//     // handle errors connecting to LaunchDarkly
+//   }
 //
 // To configure the client as a instance that you manage:
 //   client, err := flags.NewClient(
 //	   flags.WithSDKKey("foobar"),
 //   )
 //   if err != nil {
-//	   // handle invalid configuration
-//	 }
+//     // handle invalid configuration
+//   }
 //
 // The client can be configured to use the Relay Proxy in either Daemon or Proxy
 // modes. See WithDaemonMode and WithProxyMode for more information.
@@ -34,30 +34,35 @@
 // Querying for flags is done on the client instance. You can get instance from the
 // managed singleton with GetDefaultClient():
 //   client, err := flags.GetDefaultClient()
-//	 if err != nil {
-//	   // client not configured or connected
-//	 }
+//   if err != nil {
+//     // client not configured or connected
+//   }
 //
 // A typical query takes three pieces of data:
 // 1) The flag name (the "key" within the LaunchDarkly UI).
-// 2) The evaluation context, currently limited to a User object. This context
-//    contains the identifiers and attributes that flags are configured to target
-//    against.
+// 2) The evaluation context, which contains the identifiers and attributes of an
+//    entity that you wish to query the state of a flag for.
+//    There are two kinds of evaluation contexts:
+//      - Flag
+//      - Toggle
+//    Currently, the Flag kind supports a User context. The Toggle kind supports
+//    an Account context. See the evaluationcontext package for more information.
 // 3) The fallback value to return if an evaluation error occurs. This value will
 //    always be reflected as the value of the flag if err is not nil.
 //
-// In most cases, the client can automatically extract the User from the request
-// context:
-//   val, err := client.QueryBool(ctx, "my-flag", false)
+// In most cases, the client can automatically build the evaluation context from
+// the request context:
+//   flagVal, err := client.QueryBool(ctx, "flag.my-flag", false)
 //
-// You can also supply your own User as an evaluation context:
+//   toggleVal, err := client.QueryToggle(ctx, "toggle.my-toggle", false)
+//
+// You can also supply your own evaluation context:
 //   user := flags.NewUser(
-//			   "user-id",
-//			   flags.WithAccountID("account-id"),
-//	 )
-//   // user := flags.AnonymousUser() // if unauthenticated
+//             "user-id",
+//             flags.WithAccountID("account-id"),
+//   )
 //
-//   val, err := client.QueryBoolWithEvaluationContext("my-flag", user, false)
+//   val, err := client.QueryBoolWithEvaluationContext("flag.my-flag", user, false)
 //
 // When your application is shutting down, you should call Shutdown() to gracefully
 // close connections to LaunchDarkly:

--- a/x/launchdarkly/flags/evaluationcontext/account.go
+++ b/x/launchdarkly/flags/evaluationcontext/account.go
@@ -12,8 +12,7 @@ const (
 	accountEntityPrefix = "account"
 )
 
-// Account is a type of ToggleContext, representing the identifier of a customer
-// account to evaluate a toggle against.
+// Account is an evaluation context used for toggles.
 type Account struct {
 	key string
 
@@ -24,9 +23,10 @@ func (a Account) ToLDToggleUser() lduser.User {
 	return a.ldUser
 }
 
-// NewAccount returns a new account object with the given account ID.
-// accountID is the ID of a customer account, and will generally
-// be an "account_aggregate_id".
+// NewAccount returns an evaluation context representing a customer account.
+// accountID is the ID of a customer account, and will generally be an
+// "account_aggregate_id".
+// This is used for toggles only.
 func NewAccount(accountID string) Account {
 	a := &Account{
 		key: ldKey(toggleContextKind, accountEntityPrefix, accountID),

--- a/x/launchdarkly/flags/evaluationcontext/account.go
+++ b/x/launchdarkly/flags/evaluationcontext/account.go
@@ -1,0 +1,57 @@
+package evaluationcontext
+
+import (
+	"context"
+	"errors"
+
+	"github.com/cultureamp/ca-go/x/request"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+)
+
+const (
+	accountEntityPrefix = "account"
+)
+
+// Account is a type of ToggleContext, representing the identifier of a customer
+// account to evaluate a toggle against.
+type Account struct {
+	key string
+
+	ldUser lduser.User
+}
+
+func (a Account) ToLDToggleUser() lduser.User {
+	return a.ldUser
+}
+
+// NewAccount returns a new account object with the given account ID.
+// accountID is the ID of a customer account, and will generally
+// be an "account_aggregate_id".
+func NewAccount(accountID string) Account {
+	a := &Account{
+		key: ldKey(toggleContextKind, accountEntityPrefix, accountID),
+	}
+
+	userBuilder := lduser.NewUserBuilder(a.key)
+	a.ldUser = userBuilder.Build()
+
+	return *a
+}
+
+// RawUser returns the wrapped LaunchDarkly user object. The return value should
+// be casted to an lduser.User object.
+func (a Account) RawUser() interface{} {
+	return a.ldUser
+}
+
+// AccountFromContext extracts the account aggregate ID from the context. This
+// value is used to create a new Account object. An error is returned if
+// the account identifier is not present in the context.
+func AccountFromContext(ctx context.Context) (Account, error) {
+	authenticatedUser, ok := request.AuthenticatedUserFromContext(ctx)
+	if !ok {
+		return Account{}, errors.New("no AuthenticatedUser in supplied context")
+	}
+
+	return NewAccount(authenticatedUser.CustomerAccountID), nil
+}

--- a/x/launchdarkly/flags/evaluationcontext/account_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/account_test.go
@@ -1,0 +1,43 @@
+package evaluationcontext_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cultureamp/ca-go/x/launchdarkly/flags/evaluationcontext"
+	"github.com/cultureamp/ca-go/x/request"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+)
+
+func TestNewAccount(t *testing.T) {
+	t.Run("can create an account", func(t *testing.T) {
+		account := evaluationcontext.NewAccount("my-account-id")
+		assertAccountAttributes(t, account, "toggle.account.my-account-id")
+	})
+
+	t.Run("can create an account from context", func(t *testing.T) {
+		user := request.AuthenticatedUser{
+			CustomerAccountID: "123",
+			RealUserID:        "456",
+			UserID:            "789",
+		}
+		ctx := context.Background()
+
+		ctx = request.ContextWithAuthenticatedUser(ctx, user)
+
+		toggleAccount, err := evaluationcontext.AccountFromContext(ctx)
+		require.NoError(t, err)
+		assertAccountAttributes(t, toggleAccount, "toggle.account.123")
+	})
+}
+
+func assertAccountAttributes(t *testing.T, account evaluationcontext.Account, accountID string) {
+	t.Helper()
+
+	ldUser, ok := account.RawUser().(lduser.User)
+	require.True(t, ok, "should be castable to a LaunchDarkly user object")
+
+	assert.Equal(t, accountID, ldUser.GetKey())
+}

--- a/x/launchdarkly/flags/evaluationcontext/doc.go
+++ b/x/launchdarkly/flags/evaluationcontext/doc.go
@@ -1,0 +1,30 @@
+// Package evaluationcontext defines the kinds of evaluation contexts you can
+// provide in a query for a flag or product toggle. Constructor functions are
+// exposed to create valid instances of evaluation contexts.
+//
+// An evaluation context is simply a bag of attributes keyed by a unique
+// identifier. These values are used in two situations:
+//   1. When creating a flag or segment, the attributes are used to form the
+//      targeting rules. For example, "if the user's accountID is 123, return
+//      false for this flag".
+//   2. When querying for a flag in your service, the SDK uses the attributes
+//      to evaluate the rules for the flag to return the correct value. Using
+//      the same example as above, supplying a User context with an accountID
+//      of 123 would cause the flag to evaluate to false.
+//
+// You use a different kind of evaluation context depending on whether you're
+// querying a flag or a toggle. The QueryToggle functions only support the
+// Toggle evaluation contexts, for example. This design prevents you from
+// supplying the wrong kind of evaluation context for the type of query you're
+// making.
+//
+// Some evaluation contexts (like the User) have constructor functions which
+// allow you to supply optional attributes. You should always supply as many
+// attributes as you can to give yourself more flexibility when writing new
+// targeting rules. When you query a flag containing a rule that works on
+// attribute "foo", you must supply attribute "foo" in the evaluation context.
+//
+// The constructor functions will namespace the unique identifiers for the
+// evaluation contexts you send in the query. You do not need to namespace the
+// values provided to the constructor functions.
+package evaluationcontext

--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -6,14 +6,24 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
-// Context represents a set of attributes which a flag is evaluated against. The
+const (
+	flagContextKind = "flag"
+)
+
+// FlagContext represents a set of attributes which a flag is evaluated against. The
 // only context supported now is User.
-type Context interface {
-	// ToLDUser transforms the context implementation into an LDUser object that can
+type FlagContext interface {
+	// ToLDFlagUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.
-	ToLDUser() lduser.User
+	ToLDFlagUser() lduser.User
 }
 
-func ldKey(prefix, key string) string {
-	return fmt.Sprintf("%s.%s", prefix, key)
+// ldKey returns a formatted string to be used as the `key` value of the lduser.User
+// sent to LaunchDarkly. The key is comprised of three components:
+// 	1. The kind of evaluation context the key belongs to. A `flag` or `toggle`.
+// 	2. The entity prefix, for example `user` or `account`.
+//	3. The unique identifier for the entity, e.g. a user ID for the User evaluation
+//     context.
+func ldKey(contextType, prefix, key string) string {
+	return fmt.Sprintf("%s.%s.%s", contextType, prefix, key)
 }

--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -7,7 +7,8 @@ import (
 )
 
 const (
-	flagContextKind = "flag"
+	flagContextKind   = "flag"
+	toggleContextKind = "toggle"
 )
 
 // FlagContext represents a set of attributes which a flag is evaluated against. The
@@ -16,6 +17,12 @@ type FlagContext interface {
 	// ToLDFlagUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.
 	ToLDFlagUser() lduser.User
+}
+
+// ToggleContext represents a set of attributes which a product toggle is evaluated
+// against. The only context supported now is Account.
+type ToggleContext interface {
+	ToLDToggleUser() lduser.User
 }
 
 // ldKey returns a formatted string to be used as the `key` value of the lduser.User

--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -1,12 +1,10 @@
 package evaluationcontext
 
 import (
+	"fmt"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
-
-// attributeEntityType is the key of the custom attribute that will be set
-// on all evaluation context types.
-const attributeEntityType = "entityType"
 
 // Context represents a set of attributes which a flag is evaluated against. The
 // only context supported now is User.
@@ -14,4 +12,8 @@ type Context interface {
 	// ToLDUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.
 	ToLDUser() lduser.User
+}
+
+func ldKey(prefix, key string) string {
+	return fmt.Sprintf("%s.%s", prefix, key)
 }

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -16,8 +16,7 @@ var (
 	userEntityPrefix        = "user"
 )
 
-// User is a type of FlagContext, representing the identifiers and attributes of
-// a human user to evaluate a flag against.
+// User is an evaluation context used for flags.
 type User struct {
 	key        string
 	realUserID string
@@ -51,8 +50,8 @@ func WithRealUserID(id string) UserOption {
 	}
 }
 
-// NewAnonymousUser returns a user object suitable for use in unauthenticated
-// requests or requests with no access to user identifiers.
+// NewAnonymousUser returns an evaluation context representing an
+// unauthenticated user.
 // Provide a unique session or request identifier as the key if possible. If the
 // key is empty, it will default to 'ANONYMOUS_USER' and percentage rollouts
 // will not be supported.
@@ -72,9 +71,10 @@ func NewAnonymousUser(key string) User {
 	return u
 }
 
-// NewUser returns a new user object with the given user ID and options.
+// NewUser returns an evaluation context representing an authenticated user.
 // userID is the ID of the currently authenticated user, and will generally
 // be a "user_aggregate_id".
+// This is used for flags only.
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
 		key: ldKey(flagContextKind, userEntityPrefix, userID),

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -11,14 +11,14 @@ import (
 
 var (
 	anonymousUser           = "ANONYMOUS_USER"
-	userAttributeAccountID  = "user.accountID"
-	userAttributeRealUserID = "user.realUserID"
+	userAttributeAccountID  = "accountID"
+	userAttributeRealUserID = "realUserID"
 )
 
 // User is a type of context, representing the identifiers and attributes of
 // a human user to evaluate a flag against.
 type User struct {
-	userID     string
+	key        string
 	realUserID string
 	accountID  string
 
@@ -61,13 +61,10 @@ func NewAnonymousUser(key string) User {
 	}
 
 	u := User{
-		userID: key,
+		key: ldKey("anonymousUser", key),
 	}
 
-	userBuilder := lduser.NewUserBuilder(u.userID)
-	userBuilder.Custom(
-		attributeEntityType,
-		ldvalue.String("user"))
+	userBuilder := lduser.NewUserBuilder(u.key)
 	userBuilder.Anonymous(true)
 	u.ldUser = userBuilder.Build()
 
@@ -79,17 +76,14 @@ func NewAnonymousUser(key string) User {
 // be a "user_aggregate_id".
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
-		userID: userID,
+		key: ldKey("user", userID),
 	}
 
 	for _, opt := range opts {
 		opt(u)
 	}
 
-	userBuilder := lduser.NewUserBuilder(u.userID)
-	userBuilder.Custom(
-		attributeEntityType,
-		ldvalue.String("user"))
+	userBuilder := lduser.NewUserBuilder(u.key)
 	userBuilder.Custom(
 		userAttributeAccountID,
 		ldvalue.String(u.accountID))

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -16,7 +16,7 @@ var (
 	userEntityPrefix        = "user"
 )
 
-// User is a type of context, representing the identifiers and attributes of
+// User is a type of FlagContext, representing the identifiers and attributes of
 // a human user to evaluate a flag against.
 type User struct {
 	key        string

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -13,6 +13,7 @@ var (
 	anonymousUser           = "ANONYMOUS_USER"
 	userAttributeAccountID  = "accountID"
 	userAttributeRealUserID = "realUserID"
+	userEntityPrefix        = "user"
 )
 
 // User is a type of context, representing the identifiers and attributes of
@@ -25,7 +26,7 @@ type User struct {
 	ldUser lduser.User
 }
 
-func (u User) ToLDUser() lduser.User {
+func (u User) ToLDFlagUser() lduser.User {
 	return u.ldUser
 }
 
@@ -61,7 +62,7 @@ func NewAnonymousUser(key string) User {
 	}
 
 	u := User{
-		key: ldKey("anonymousUser", key),
+		key: ldKey(flagContextKind, userEntityPrefix, key),
 	}
 
 	userBuilder := lduser.NewUserBuilder(u.key)
@@ -76,7 +77,7 @@ func NewAnonymousUser(key string) User {
 // be a "user_aggregate_id".
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
-		key: ldKey("user", userID),
+		key: ldKey(flagContextKind, userEntityPrefix, userID),
 	}
 
 	for _, opt := range opts {

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -14,23 +14,23 @@ import (
 func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("")
-		assertUserAttributes(t, user, "ANONYMOUS_USER", "", "")
+		assertUserAttributes(t, user, "anonymousUser.ANONYMOUS_USER", "", "")
 	})
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
-		assertUserAttributes(t, user, "my-request-id", "", "")
+		assertUserAttributes(t, user, "anonymousUser.my-request-id", "", "")
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {
 		user := evaluationcontext.NewUser("not-a-uuid")
-		assertUserAttributes(t, user, "not-a-uuid", "", "")
+		assertUserAttributes(t, user, "user.not-a-uuid", "", "")
 
 		user = evaluationcontext.NewUser(
 			"not-a-uuid",
 			evaluationcontext.WithAccountID("not-a-uuid"),
 			evaluationcontext.WithRealUserID("not-a-uuid"))
-		assertUserAttributes(t, user, "not-a-uuid", "not-a-uuid", "not-a-uuid")
+		assertUserAttributes(t, user, "user.not-a-uuid", "not-a-uuid", "not-a-uuid")
 	})
 
 	t.Run("can create a user from context", func(t *testing.T) {
@@ -45,18 +45,17 @@ func TestNewUser(t *testing.T) {
 
 		flagsUser, err := evaluationcontext.UserFromContext(ctx)
 		require.NoError(t, err)
-		assertUserAttributes(t, flagsUser, "789", "456", "123")
+		assertUserAttributes(t, flagsUser, "user.789", "456", "123")
 	})
 }
 
-func assertUserAttributes(t *testing.T, user evaluationcontext.User, effectiveUserAggregateID, realUserAggregateID, accountAggregateID string) {
+func assertUserAttributes(t *testing.T, user evaluationcontext.User, userID, realUserID, accountID string) {
 	t.Helper()
 
 	ldUser, ok := user.RawUser().(lduser.User)
 	require.True(t, ok, "should be castable to a LaunchDarkly user object")
 
-	assert.Equal(t, effectiveUserAggregateID, ldUser.GetKey())
-	assert.Equal(t, realUserAggregateID, ldUser.GetAttribute("user.realUserID").StringValue())
-	assert.Equal(t, accountAggregateID, ldUser.GetAttribute("user.accountID").StringValue())
-	assert.Equal(t, "user", ldUser.GetAttribute("entityType").StringValue())
+	assert.Equal(t, userID, ldUser.GetKey())
+	assert.Equal(t, realUserID, ldUser.GetAttribute("realUserID").StringValue())
+	assert.Equal(t, accountID, ldUser.GetAttribute("accountID").StringValue())
 }

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -14,23 +14,23 @@ import (
 func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("")
-		assertUserAttributes(t, user, "anonymousUser.ANONYMOUS_USER", "", "")
+		assertUserAttributes(t, user, "flag.user.ANONYMOUS_USER", "", "")
 	})
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
-		assertUserAttributes(t, user, "anonymousUser.my-request-id", "", "")
+		assertUserAttributes(t, user, "flag.user.my-request-id", "", "")
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {
 		user := evaluationcontext.NewUser("not-a-uuid")
-		assertUserAttributes(t, user, "user.not-a-uuid", "", "")
+		assertUserAttributes(t, user, "flag.user.not-a-uuid", "", "")
 
 		user = evaluationcontext.NewUser(
 			"not-a-uuid",
 			evaluationcontext.WithAccountID("not-a-uuid"),
 			evaluationcontext.WithRealUserID("not-a-uuid"))
-		assertUserAttributes(t, user, "user.not-a-uuid", "not-a-uuid", "not-a-uuid")
+		assertUserAttributes(t, user, "flag.user.not-a-uuid", "not-a-uuid", "not-a-uuid")
 	})
 
 	t.Run("can create a user from context", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNewUser(t *testing.T) {
 
 		flagsUser, err := evaluationcontext.UserFromContext(ctx)
 		require.NoError(t, err)
-		assertUserAttributes(t, flagsUser, "user.789", "456", "123")
+		assertUserAttributes(t, flagsUser, "flag.user.789", "456", "123")
 	})
 }
 


### PR DESCRIPTION
This PR adds support to the `flags` package for querying product toggles, in addition to feature flags.

It makes a couple of changes to accomplish this:

- The existing evaluation contexts for creating a User object have been namespaced. This reflects that User contexts are only valid for flag queries.
- A new kind of evaluation context (Toggle) has been introduced, along with an Account object used to query product toggles.
- The package documentation for `flags` has been improved to clarify how evaluation contexts are used.
- New package documentation for `evaluationcontext` has been added, providing more context (heh) on what the evaluation context is and how it is used.
- The `key` values sent in the evaluation contexts are prefixed with the kind and the entity type. For example, a User context will result in a key of `flag.user.<user-aggregate-id>`. An Account context will result in `toggle.account.<account-aggregate-id>`.