### PR TITLE
feat: prefix evaluation context keys

### DIFF
--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -1,6 +1,6 @@
-// Package flags provides access to feature flags. It wraps the LaunchDarkly SDK
-// to expose a convenient and consistent way of configuring and using the
-// client.
+// Package flags provides access to feature flags and product toggles. It wraps
+// the LaunchDarkly SDK and exposes a convenient and consistent way of configuring
+// and using the client.
 //
 // The client can be configured and used as a managed singleton or as an
 // instance returned from a constructor function. The managed singleton provides
@@ -17,16 +17,16 @@
 //
 //   err = flags.Connect()
 //   if err != nil {
-//	   // handle errors connecting to LaunchDarkly
-//	 }
+//     // handle errors connecting to LaunchDarkly
+//   }
 //
 // To configure the client as a instance that you manage:
 //   client, err := flags.NewClient(
 //	   flags.WithSDKKey("foobar"),
 //   )
 //   if err != nil {
-//	   // handle invalid configuration
-//	 }
+//     // handle invalid configuration
+//   }
 //
 // The client can be configured to use the Relay Proxy in either Daemon or Proxy
 // modes. See WithDaemonMode and WithProxyMode for more information.
@@ -34,30 +34,32 @@
 // Querying for flags is done on the client instance. You can get instance from the
 // managed singleton with GetDefaultClient():
 //   client, err := flags.GetDefaultClient()
-//	 if err != nil {
-//	   // client not configured or connected
-//	 }
+//   if err != nil {
+//     // client not configured or connected
+//   }
 //
 // A typical query takes three pieces of data:
 // 1) The flag name (the "key" within the LaunchDarkly UI).
-// 2) The evaluation context, currently limited to a User object. This context
-//    contains the identifiers and attributes that flags are configured to target
-//    against.
+// 2) The evaluation context, which contains the identifiers and attributes of an
+//    entity that you wish to query the state of a flag for. See the
+//    evaluationcontext package for more information.
 // 3) The fallback value to return if an evaluation error occurs. This value will
 //    always be reflected as the value of the flag if err is not nil.
 //
-// In most cases, the client can automatically extract the User from the request
-// context:
-//   val, err := client.QueryBool(ctx, "my-flag", false)
+// In most cases, the client can automatically build the evaluation context from
+// the request context (provided the context has been augmented with the
+// ca-go/request package):
+//   flagVal, err := client.QueryBool(ctx, "flag.my-flag", false)
 //
-// You can also supply your own User as an evaluation context:
+//   toggleVal, err := client.QueryToggle(ctx, "toggle.my-toggle", false)
+//
+// You can also supply your own evaluation context:
 //   user := flags.NewUser(
-//			   "user-id",
-//			   flags.WithAccountID("account-id"),
-//	 )
-//   // user := flags.AnonymousUser() // if unauthenticated
+//             "user-id",
+//             flags.WithAccountID("account-id"),
+//   )
 //
-//   val, err := client.QueryBoolWithEvaluationContext("my-flag", user, false)
+//   val, err := client.QueryBoolWithEvaluationContext("flag.my-flag", user, false)
 //
 // When your application is shutting down, you should call Shutdown() to gracefully
 // close connections to LaunchDarkly:

--- a/x/launchdarkly/flags/evaluationcontext/doc.go
+++ b/x/launchdarkly/flags/evaluationcontext/doc.go
@@ -1,0 +1,25 @@
+// Package evaluationcontext defines the kinds of evaluation contexts you can
+// provide in a query for a flag or product toggle. Constructor functions are
+// exposed to create valid instances of evaluation contexts.
+//
+// An evaluation context is simply a bag of attributes keyed by a unique
+// identifier. These values are used in two situations:
+//   1. When creating a flag or segment, the attributes are used to form the
+//      targeting rules. For example, "if the user's accountID is 123, return
+//      false for this flag".
+//   2. When querying for a flag in your service, the SDK uses the attributes
+//      to evaluate the rules for the flag to return the correct value. Using
+//      the same example as above, supplying a User context with an accountID
+//      of 123 would cause the flag to evaluate to false.
+//
+// Some evaluation contexts (like the User) have constructor functions which
+// allow you to supply optional attributes. You should always supply as many
+// attributes as you can to give yourself more flexibility when writing new
+// targeting rules. When you query a flag containing a rule that works on
+// attribute "foo", you must supply attribute "foo" in the evaluation context.
+//
+// The constructor functions will namespace the key of the evaluation context
+// you send in the query. You do not need to prefix the values provided to
+// the constructor functions with the entity type. For example, supply the user
+// ID as-is rather than prefixing as `user.<user-id>`.
+package evaluationcontext

--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -1,12 +1,10 @@
 package evaluationcontext
 
 import (
+	"fmt"
+
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
-
-// attributeEntityType is the key of the custom attribute that will be set
-// on all evaluation context types.
-const attributeEntityType = "entityType"
 
 // Context represents a set of attributes which a flag is evaluated against. The
 // only context supported now is User.
@@ -14,4 +12,8 @@ type Context interface {
 	// ToLDUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.
 	ToLDUser() lduser.User
+}
+
+func ldKey(prefix, key string) string {
+	return fmt.Sprintf("%s.%s", prefix, key)
 }

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -9,16 +9,17 @@ import (
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
-var (
+const (
 	anonymousUser           = "ANONYMOUS_USER"
-	userAttributeAccountID  = "user.accountID"
-	userAttributeRealUserID = "user.realUserID"
+	userAttributeAccountID  = "accountID"
+	userAttributeRealUserID = "realUserID"
+	userEntityPrefix        = "user"
 )
 
 // User is a type of context, representing the identifiers and attributes of
 // a human user to evaluate a flag against.
 type User struct {
-	userID     string
+	key        string
 	realUserID string
 	accountID  string
 
@@ -61,13 +62,10 @@ func NewAnonymousUser(key string) User {
 	}
 
 	u := User{
-		userID: key,
+		key: ldKey(userEntityPrefix, key),
 	}
 
-	userBuilder := lduser.NewUserBuilder(u.userID)
-	userBuilder.Custom(
-		attributeEntityType,
-		ldvalue.String("user"))
+	userBuilder := lduser.NewUserBuilder(u.key)
 	userBuilder.Anonymous(true)
 	u.ldUser = userBuilder.Build()
 
@@ -79,17 +77,14 @@ func NewAnonymousUser(key string) User {
 // be a "user_aggregate_id".
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
-		userID: userID,
+		key: ldKey(userEntityPrefix, userID),
 	}
 
 	for _, opt := range opts {
 		opt(u)
 	}
 
-	userBuilder := lduser.NewUserBuilder(u.userID)
-	userBuilder.Custom(
-		attributeEntityType,
-		ldvalue.String("user"))
+	userBuilder := lduser.NewUserBuilder(u.key)
 	userBuilder.Custom(
 		userAttributeAccountID,
 		ldvalue.String(u.accountID))

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -14,23 +14,23 @@ import (
 func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("")
-		assertUserAttributes(t, user, "ANONYMOUS_USER", "", "")
+		assertUserAttributes(t, user, "user.ANONYMOUS_USER", "", "")
 	})
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
-		assertUserAttributes(t, user, "my-request-id", "", "")
+		assertUserAttributes(t, user, "user.my-request-id", "", "")
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {
 		user := evaluationcontext.NewUser("not-a-uuid")
-		assertUserAttributes(t, user, "not-a-uuid", "", "")
+		assertUserAttributes(t, user, "user.not-a-uuid", "", "")
 
 		user = evaluationcontext.NewUser(
 			"not-a-uuid",
 			evaluationcontext.WithAccountID("not-a-uuid"),
 			evaluationcontext.WithRealUserID("not-a-uuid"))
-		assertUserAttributes(t, user, "not-a-uuid", "not-a-uuid", "not-a-uuid")
+		assertUserAttributes(t, user, "user.not-a-uuid", "not-a-uuid", "not-a-uuid")
 	})
 
 	t.Run("can create a user from context", func(t *testing.T) {
@@ -45,18 +45,17 @@ func TestNewUser(t *testing.T) {
 
 		flagsUser, err := evaluationcontext.UserFromContext(ctx)
 		require.NoError(t, err)
-		assertUserAttributes(t, flagsUser, "789", "456", "123")
+		assertUserAttributes(t, flagsUser, "user.789", "456", "123")
 	})
 }
 
-func assertUserAttributes(t *testing.T, user evaluationcontext.User, effectiveUserAggregateID, realUserAggregateID, accountAggregateID string) {
+func assertUserAttributes(t *testing.T, user evaluationcontext.User, userID, realUserID, accountID string) {
 	t.Helper()
 
 	ldUser, ok := user.RawUser().(lduser.User)
 	require.True(t, ok, "should be castable to a LaunchDarkly user object")
 
-	assert.Equal(t, effectiveUserAggregateID, ldUser.GetKey())
-	assert.Equal(t, realUserAggregateID, ldUser.GetAttribute("user.realUserID").StringValue())
-	assert.Equal(t, accountAggregateID, ldUser.GetAttribute("user.accountID").StringValue())
-	assert.Equal(t, "user", ldUser.GetAttribute("entityType").StringValue())
+	assert.Equal(t, userID, ldUser.GetKey())
+	assert.Equal(t, realUserID, ldUser.GetAttribute("realUserID").StringValue())
+	assert.Equal(t, accountID, ldUser.GetAttribute("accountID").StringValue())
 }


### PR DESCRIPTION
This PR modifies the `flags` package to prefix the keys used in the evaluation context sent to LaunchDarkly. The prefix will be the type of entity represented by the context, for example a `user` or `survey`, and is used to logically distinguish different business entities used in LD for flag targeting.

Along with this change, the PR updates the docs for the `flags` package to fix some whitespace problems. The PR also adds package documentation to `evaluationcontext` as it's a bit of a tricky concept to explain.