### PR TITLE
fix: set a default init wait time

### DIFF
--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -25,7 +25,10 @@ type Client struct {
 // returned if mandatory ConfigOptions are not supplied, or an invalid
 // combination of options is provided.
 func NewClient(opts ...ConfigOption) (*Client, error) {
-	c := &Client{}
+	c := &Client{
+		initWait: 5 * time.Second, // wait up to 5 seconds for LD to connect
+	}
+
 	for _, opt := range opts {
 		opt(c)
 	}

--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -37,6 +37,8 @@ func WithSDKKey(key string) ConfigOption {
 
 // WithInitWait configures the client to wait for the given duration for the
 // LaunchDarkly client to connect.
+// If you don't provide this option, the client will wait up to 5 seconds by
+// default.
 func WithInitWait(t time.Duration) ConfigOption {
 	return func(c *Client) {
 		c.initWait = t


### PR DESCRIPTION
This PR modifies the `flags` package to set a default initWait value of 5 seconds. The initWait value specifies how long the LD client should block while it's waiting to establish an initial connection to LD, and to download the set of flags and rules.

Previously, there was no default and the documentation did not cover that a custom initWait value should be specified. This caused issues where users attempted to query for a flag with a client that had not yet initialised, leading to an error.

5 seconds seems like a sensible default for the kinds of payload sizes we would expect, given the number of flags and rules we would have during the initial rollout. The option always exists to override this value with a custom value.