### PR TITLE
feat: stop prefixing user keys in the evaluation context

### DIFF
--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -1,8 +1,6 @@
 package evaluationcontext
 
 import (
-	"fmt"
-
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
@@ -12,8 +10,4 @@ type Context interface {
 	// ToLDUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.
 	ToLDUser() lduser.User
-}
-
-func ldKey(prefix, key string) string {
-	return fmt.Sprintf("%s.%s", prefix, key)
 }

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -13,7 +13,6 @@ const (
 	anonymousUser           = "ANONYMOUS_USER"
 	userAttributeAccountID  = "accountID"
 	userAttributeRealUserID = "realUserID"
-	userEntityPrefix        = "user"
 )
 
 // User is a type of context, representing the identifiers and attributes of
@@ -62,7 +61,7 @@ func NewAnonymousUser(key string) User {
 	}
 
 	u := User{
-		key: ldKey(userEntityPrefix, key),
+		key: key,
 	}
 
 	userBuilder := lduser.NewUserBuilder(u.key)
@@ -77,7 +76,7 @@ func NewAnonymousUser(key string) User {
 // be a "user_aggregate_id".
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
-		key: ldKey(userEntityPrefix, userID),
+		key: userID,
 	}
 
 	for _, opt := range opts {

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -14,23 +14,23 @@ import (
 func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("")
-		assertUserAttributes(t, user, "user.ANONYMOUS_USER", "", "")
+		assertUserAttributes(t, user, "ANONYMOUS_USER", "", "")
 	})
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
-		assertUserAttributes(t, user, "user.my-request-id", "", "")
+		assertUserAttributes(t, user, "my-request-id", "", "")
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {
 		user := evaluationcontext.NewUser("not-a-uuid")
-		assertUserAttributes(t, user, "user.not-a-uuid", "", "")
+		assertUserAttributes(t, user, "not-a-uuid", "", "")
 
 		user = evaluationcontext.NewUser(
 			"not-a-uuid",
 			evaluationcontext.WithAccountID("not-a-uuid"),
 			evaluationcontext.WithRealUserID("not-a-uuid"))
-		assertUserAttributes(t, user, "user.not-a-uuid", "not-a-uuid", "not-a-uuid")
+		assertUserAttributes(t, user, "not-a-uuid", "not-a-uuid", "not-a-uuid")
 	})
 
 	t.Run("can create a user from context", func(t *testing.T) {
@@ -45,7 +45,7 @@ func TestNewUser(t *testing.T) {
 
 		flagsUser, err := evaluationcontext.UserFromContext(ctx)
 		require.NoError(t, err)
-		assertUserAttributes(t, flagsUser, "user.789", "456", "123")
+		assertUserAttributes(t, flagsUser, "789", "456", "123")
 	})
 }
 


### PR DESCRIPTION
Modifies the LaunchDarkly wrapper.

Removes the `user.` prefix from the key of the User evaluation context.
This optimises for the common case -- targeting against user attributes
-- and reduces complexity that would be needed in systems wishing to
integrate with our model of a user.