### PR TITLE
fix: don't route analytics events through the LD Relay

### DIFF
--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -121,7 +121,7 @@ func WithDynamoBaseURL(baseURL *url.URL) ConfigOption {
 
 func configForProxyMode(cfg *proxyModeConfig) ld.Config {
 	return ld.Config{
-		ServiceEndpoints: ldcomponents.RelayProxyEndpoints(cfg.relayProxyURL),
+		ServiceEndpoints: ldcomponents.RelayProxyEndpointsWithoutEvents(cfg.relayProxyURL),
 	}
 }
 


### PR DESCRIPTION
Configures the proxy mode option of the LaunchDarkly SDK so that analytics events are _not_ routed through the Relay Proxy. This is being done because:

- Routing events through the Relay generates additional traffic.
- The [default Relay configuration](https://github.com/launchdarkly/ld-relay/blob/v6/docs/configuration.md#file-section-events) has event forwarding turned off.
- The use case for sending events via the Relay only highlights a benefit for [PHP environments](https://github.com/launchdarkly/ld-relay/blob/v6/docs/events.md).