### PR TITLE
[COSE-24] Update LD Wrapper to match Ruby Wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 require (
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/google/uuid v1.3.0 // indirect
+	github.com/google/uuid v1.3.0
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -54,7 +54,7 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 	if c.sdkKey == "" {
 		defaultSDKKey, ok := os.LookupEnv(defaultSDKKeyEnvironmentVariable)
 		if !ok {
-			return nil, errors.New("LaunchDarkly SDK key not supplied via config option and the LAUNCHDARKLY_SDK_KEY environment variable does not exist")
+			return nil, errors.New("LaunchDarkly SDK key not supplied via config option and the LAUNCHDARKLY_CONFIGURATION environment variable does not exist")
 		}
 		c.sdkKey = defaultSDKKey
 	}
@@ -63,10 +63,10 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 		return nil, errors.New("cannot configure the SDK for Proxy and Daemon modes simultaneously")
 	}
 
-	if c.proxyModeConfig != nil {
-		c.wrappedConfig = configForProxyMode(c.proxyModeConfig)
-	} else if c.daemonModeConfig != nil {
-		c.wrappedConfig = configForDaemonMode(c.daemonModeConfig)
+	if parsedConfig.Options.Proxy != nil {
+		c.wrappedConfig = configForProxyMode(parsedConfig.Options.Proxy)
+	} else if parsedConfig.Options.DaemonMode != nil {
+		c.wrappedConfig = configForDaemonMode(parsedConfig.Options.DaemonMode)
 	}
 
 	return c, nil

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -2,10 +2,8 @@ package flags
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"github.com/cultureamp/ca-go/x/launchdarkly/flags/evaluationcontext"
@@ -14,35 +12,32 @@ import (
 
 // Client is a wrapper around the LaunchDarkly client.
 type Client struct {
-	sdkKey           string
-	initWait         time.Duration
-	proxyModeConfig  *proxyModeConfig
-	daemonModeConfig *daemonModeConfig
-	wrappedConfig    ld.Config
-	wrappedClient    *ld.LDClient
+	sdkKey        string
+	initWait      time.Duration
+	mode          mode
+	wrappedConfig ld.Config
+	wrappedClient *ld.LDClient
 }
 
-// NewClient configures and returns an instance of the client. It configures the client automatically based on the value of the
-// LAUNCHDARKLY_CONFIGURATION environment variable. You should declare this
-// variable in your CDK configuration for your infrastructure. The correct value
-// can be retrieved from the AWS Secrets Manager under the key
-// `/common/launchdarkly-ops/sdk-configuration/<farm>`. An error is
-// returned if mandatory ConfigOptions are not supplied, or an invalid
-// combination of options is provided.
+// The mode the SDK should be configured for.
+type mode int
+
+const (
+	modeProxy  mode = iota // proxies requests through the LD Relay.
+	modeLambda             // connects directly to DynamoDB.
+)
+
+// NewClient configures and returns an instance of the client. An
+// error is returned if unable to configure from environment variable
 func NewClient(opts ...ConfigOption) (*Client, error) {
 	c := &Client{
-		initWait: 5 * time.Second, // wait up to 5 seconds for LD to connect
+		initWait: 5 * time.Second, // wait up to 5 seconds for LD to connect.
+		mode:     modeProxy,       // defaults to proxying requests through the LD Relay.
 	}
 
-	var parsedConfig configurationJSON
-
-	configEnvVar, ok := os.LookupEnv("LAUNCHDARKLY_CONFIGURATION")
-	if !ok {
-		return nil, errors.New("environment variable LAUNCHDARKLY_CONFIGURATION does not exist")
-	}
-
-	if err := json.Unmarshal([]byte(configEnvVar), &parsedConfig); err != nil {
-		return nil, fmt.Errorf("parse LAUNCHDARKLY_CONFIGURATION: %w", err)
+	parsedConfig, err := configFromEnvironment()
+	if err != nil {
+		return nil, fmt.Errorf("configure from environment variable: %w", err)
 	}
 
 	c.sdkKey = parsedConfig.SDKKey
@@ -51,22 +46,12 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 		opt(c)
 	}
 
-	if c.sdkKey == "" {
-		defaultSDKKey, ok := os.LookupEnv(defaultSDKKeyEnvironmentVariable)
-		if !ok {
-			return nil, errors.New("LaunchDarkly SDK key not supplied via config option and the LAUNCHDARKLY_CONFIGURATION environment variable does not exist")
-		}
-		c.sdkKey = defaultSDKKey
-	}
-
-	if c.proxyModeConfig != nil && c.daemonModeConfig != nil {
-		return nil, errors.New("cannot configure the SDK for Proxy and Daemon modes simultaneously")
-	}
-
-	if parsedConfig.Options.Proxy != nil {
+	if parsedConfig.Options.Proxy != nil && c.mode == modeProxy {
 		c.wrappedConfig = configForProxyMode(parsedConfig.Options.Proxy)
-	} else if parsedConfig.Options.DaemonMode != nil {
-		c.wrappedConfig = configForDaemonMode(parsedConfig.Options.DaemonMode)
+	}
+
+	if parsedConfig.Options.DaemonMode != nil && c.mode == modeLambda {
+		c.wrappedConfig = configForLambdaMode(parsedConfig.Options.DaemonMode)
 	}
 
 	return c, nil
@@ -85,7 +70,7 @@ func (c *Client) Connect() error {
 		return fmt.Errorf("create LaunchDarkly client: %w", err)
 	}
 
-	flagsClient.wrappedClient = wrappedClient
+	c.wrappedClient = wrappedClient
 
 	return nil
 }

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -1,7 +1,6 @@
 package flags_test
 
 import (
-	"net/url"
 	"os"
 	"testing"
 	"time"
@@ -10,70 +9,17 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitialisationClient(t *testing.T) {
-	t.Run("errors if an SDK key is not supplied", func(t *testing.T) {
+func TestClientInitialisation(t *testing.T) {
+	t.Run("errors if no env var is supplied", func(t *testing.T) {
 		_, err := flags.NewClient()
 		require.Error(t, err)
-	})
-
-	t.Run("does not error if SDK key supplied as env var", func(t *testing.T) {
-		os.Setenv("LAUNCHDARKLY_SDK_KEY", "foobar")
-		defer os.Unsetenv("LAUNCHDARKLY_SDK_KEY")
-		_, err := flags.NewClient()
-		require.NoError(t, err)
-	})
-
-	t.Run("does not error if SDK key supplied as config option", func(t *testing.T) {
-		_, err := flags.NewClient(flags.WithSDKKey("foobar"))
-		require.NoError(t, err)
 	})
 
 	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {
+		os.Setenv("LAUNCHDARKLY_CONFIGURATION", "{\"sdkKey\": \"abc\"}")
+		defer os.Unsetenv("LAUNCHDARKLY_CONFIGURATION")
 		_, err := flags.NewClient(
-			flags.WithSDKKey("foobar"),
-			flags.WithInitWait(2*time.Second))
+			flags.WithInitWait(2 * time.Second))
 		require.NoError(t, err)
-	})
-
-	t.Run("allows a Relay Proxy URL to be specified", func(t *testing.T) {
-		proxyURL, err := url.Parse("http://localhost:8030")
-		require.NoError(t, err)
-
-		_, err = flags.NewClient(
-			flags.WithSDKKey("foobar"),
-			flags.WithProxyMode(proxyURL))
-		require.NoError(t, err)
-	})
-
-	t.Run("allows daemon mode to be configured", func(t *testing.T) {
-		_, err := flags.NewClient(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-		)
-		require.NoError(t, err)
-	})
-
-	t.Run("allows daemon mode to be configured with an alterate Dynamo base URL", func(t *testing.T) {
-		baseURL, err := url.Parse("http://localhost:6789")
-		require.NoError(t, err)
-
-		_, err = flags.NewClient(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-			flags.WithDynamoBaseURL(baseURL),
-		)
-		require.NoError(t, err)
-	})
-
-	t.Run("does not allow both proxy and daemon modes", func(t *testing.T) {
-		proxyURL, err := url.Parse("http://localhost:8030")
-		require.NoError(t, err)
-
-		_, err = flags.NewClient(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-			flags.WithProxyMode(proxyURL),
-		)
-		require.Error(t, err)
 	})
 }

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -1,25 +1,67 @@
-package flags_test
+package flags
 
 import (
 	"os"
 	"testing"
 	"time"
 
-	"github.com/cultureamp/ca-go/x/launchdarkly/flags"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-func TestClientInitialisation(t *testing.T) {
-	t.Run("errors if no env var is supplied", func(t *testing.T) {
-		_, err := flags.NewClient()
+const validConfigJSON = `
+{
+    "sdkKey":"super-secret-key",
+    "options":{
+        "daemonMode":{
+            "dynamo_base_url":"url-here",
+            "DynamoTableName":"my-dynamo-table",
+            "dynamoCacheTTLSeconds":30
+        },
+        "proxyMode":{
+            "url":"https://relay-proxy.cultureamp.net"
+        }
+    }
+}
+`
+
+func TestInitialisationClient(t *testing.T) {
+	t.Run("errors if an SDK key is not supplied", func(t *testing.T) {
+		_, err := NewClient()
 		require.Error(t, err)
 	})
 
 	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {
-		os.Setenv("LAUNCHDARKLY_CONFIGURATION", "{\"sdkKey\": \"abc\"}")
-		defer os.Unsetenv("LAUNCHDARKLY_CONFIGURATION")
-		_, err := flags.NewClient(
-			flags.WithInitWait(2 * time.Second))
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+
+		client, err := NewClient(
+			WithInitWait(2 * time.Second))
 		require.NoError(t, err)
+		assert.Equal(t, client.initWait, 2*time.Second)
+	})
+
+	t.Run("configures for Lambda (daemon) mode", func(t *testing.T) {
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+
+		client, err := NewClient(WithLambdaMode())
+		require.NoError(t, err)
+
+		err = client.Connect()
+		require.NoError(t, err)
+
+		assert.True(t, client.wrappedClient.GetDataStoreStatusProvider().GetStatus().Available)
+	})
+
+	t.Run("configures for proxy mode", func(t *testing.T) {
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+		client, err := NewClient()
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://relay-proxy.cultureamp.net", client.wrappedConfig.ServiceEndpoints.Streaming)
+		assert.Equal(t, "https://relay-proxy.cultureamp.net", client.wrappedConfig.ServiceEndpoints.Events)
+		assert.Equal(t, "https://relay-proxy.cultureamp.net", client.wrappedConfig.ServiceEndpoints.Polling)
 	})
 }

--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -1,11 +1,8 @@
 package flags
 
 import (
-	"encoding/json"
 	"errors"
-	"fmt"
 	"net/url"
-	"os"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -35,39 +32,6 @@ type configurationJSON struct {
 // ConfigOption are functions that can be supplied to Configure and NewClient to
 // configure the flags client.
 type ConfigOption func(c *Client)
-
-// FromEnvironment configures the client automatically based on the value of the
-// LAUNCHDARKLY_CONFIGURATION environment variable. You should declare this
-// variable in your CDK configuration for your infrastructure. The correct value
-// can be retrieved from the AWS Secrets Manager under the key
-// `/common/launchdarkly-ops/sdk-configuration/<farm>`.
-//
-// This option panics if LAUNCHDARKLY_CONFIGURATION could not be found or
-// parsed.
-func FromEnvironment() ConfigOption {
-	var parsedConfig configurationJSON
-
-	configEnvVar, ok := os.LookupEnv("LAUNCHDARKLY_CONFIGURATION")
-	if !ok {
-		panic(errors.New("environment variable LAUNCHDARKLY_CONFIGURATION does not exist"))
-	}
-
-	if err := json.Unmarshal([]byte(configEnvVar), &parsedConfig); err != nil {
-		panic(fmt.Errorf("parse LAUNCHDARKLY_CONFIGURATION: %w", err))
-	}
-
-	return func(c *Client) {
-		c.sdkKey = parsedConfig.SDKKey
-	}
-}
-
-// WithSDKKey configures the client to use the given SDK key to authenticate
-// against LaunchDarkly.
-func WithSDKKey(key string) ConfigOption {
-	return func(c *Client) {
-		c.sdkKey = key
-	}
-}
 
 // WithInitWait configures the client to wait for the given duration for the
 // LaunchDarkly client to connect.

--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -13,7 +13,7 @@
 // a handle on the flags client.
 //
 // To configure the client as a singleton:
-//   err := flags.Configure(flags.FromEnvironment())
+//   err := flags.Configure()
 //   if err != nil {
 //     // handle invalid configuration
 //   }
@@ -24,7 +24,7 @@
 //   }
 //
 // To configure the client as a instance that you manage:
-//   client, err := flags.NewClient(flags.FromEnvironment())
+//   client, err := flags.NewClient()
 //   if err != nil {
 //     // handle invalid configuration
 //   }
@@ -50,9 +50,7 @@
 // In most cases, the client can automatically build the evaluation context from
 // the request context (provided the context has been augmented with the
 // ca-go/request package):
-//   flagVal, err := client.QueryBool(ctx, "flag.my-flag", false)
-//
-//   toggleVal, err := client.QueryToggle(ctx, "toggle.my-toggle", false)
+//   flagVal, err := client.QueryBool(ctx, "my-flag", false)
 //
 // You can also supply your own evaluation context:
 //   user := flags.NewUser(
@@ -60,7 +58,7 @@
 //             flags.WithAccountID("account-id"),
 //   )
 //
-//   val, err := client.QueryBoolWithEvaluationContext("flag.my-flag", user, false)
+//   val, err := client.QueryBoolWithEvaluationContext("my-flag", user, false)
 //
 // When your application is shutting down, you should call Shutdown() to gracefully
 // close connections to LaunchDarkly:

--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -2,10 +2,12 @@
 // the LaunchDarkly SDK and exposes a convenient and consistent way of configuring
 // and using the client.
 //
-// The client can be configured automatically based on the presence of an environment
-// variable. You can override this behaviour by supplying ConfigOption arguments
-// manually. For more information, see the docs on flags.FromEnvironment() and
-// the ConfigOption functions in config.go.
+// The client is configured automatically based on the presence of the
+// LAUNCHDARKLY_CONFIGURATION environment variable which contains a JSON structured
+// string. You should declare this variable in your CDK configuration for your
+// infrastructure. The correct value for the environment your service is running
+// in can be retrieved from the AWS Secrets Manager under the key
+// `/common/launchdarkly-ops/sdk-configuration/<farm>`.
 //
 // The client can be configured and used as a managed singleton or as an
 // instance returned from a constructor function. The managed singleton provides
@@ -29,8 +31,9 @@
 //     // handle invalid configuration
 //   }
 //
-// The client can be configured to use the Relay Proxy in either Daemon or Proxy
-// modes. See WithDaemonMode and WithProxyMode for more information.
+// The client will attempt to proxy requests through the LD Relay by default. You
+// can optionally choose to connect directly to DynamoDB by specifying the
+// WithLambdaMode() option to the flags.NewClient() or flags.Configure() functions.
 //
 // Querying for flags is done on the client instance. You can get instance from the
 // managed singleton with GetDefaultClient():

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -5,12 +5,12 @@ import (
 	"errors"
 
 	"github.com/cultureamp/ca-go/x/request"
+	"github.com/google/uuid"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
 const (
-	anonymousUser           = "ANONYMOUS_USER"
 	userAttributeAccountID  = "accountID"
 	userAttributeRealUserID = "realUserID"
 )
@@ -57,7 +57,7 @@ func WithRealUserID(id string) UserOption {
 // will not be supported.
 func NewAnonymousUser(key string) User {
 	if key == "" {
-		key = anonymousUser
+		key = uuid.NewString()
 	}
 
 	u := User{
@@ -93,12 +93,6 @@ func NewUser(userID string, opts ...UserOption) User {
 	u.ldUser = userBuilder.Build()
 
 	return *u
-}
-
-// RawUser returns the wrapped LaunchDarkly user object. The return value should
-// be casted to an lduser.User object.
-func (u User) RawUser() interface{} {
-	return u.ldUser
 }
 
 // UserFromContext extracts the effective user aggregate ID, real user aggregate

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/cultureamp/ca-go/x/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
 )
 
 func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("")
-		assertUserAttributes(t, user, "ANONYMOUS_USER", "", "")
+		ldUser := user.ToLDUser()
+		assert.True(t, ldUser.GetAnonymous())
 	})
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
@@ -52,8 +52,7 @@ func TestNewUser(t *testing.T) {
 func assertUserAttributes(t *testing.T, user evaluationcontext.User, userID, realUserID, accountID string) {
 	t.Helper()
 
-	ldUser, ok := user.RawUser().(lduser.User)
-	require.True(t, ok, "should be castable to a LaunchDarkly user object")
+	ldUser := user.ToLDUser()
 
 	assert.Equal(t, userID, ldUser.GetKey())
 	assert.Equal(t, realUserID, ldUser.GetAttribute("realUserID").StringValue())

--- a/x/launchdarkly/flags/flags.go
+++ b/x/launchdarkly/flags/flags.go
@@ -6,14 +6,10 @@ import (
 
 var flagsClient *Client
 
-const defaultSDKKeyEnvironmentVariable = "LAUNCHDARKLY_SDK_KEY"
-
 // FlagName establishes a type for flag names.
 type FlagName string
 
-// Configure configures the client as a managed singleton. An error is returned
-// if mandatory ConfigOptions are not supplied, or an invalid combination of
-// options is provided.
+// Configure configures the client as a managed singleton.
 func Configure(opts ...ConfigOption) error {
 	c, err := NewClient(opts...)
 	if err != nil {

--- a/x/launchdarkly/flags/flags_test.go
+++ b/x/launchdarkly/flags/flags_test.go
@@ -1,26 +1,26 @@
-package flags_test
+package flags
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
-	"github.com/cultureamp/ca-go/x/launchdarkly/flags"
 	"github.com/stretchr/testify/require"
 )
 
 func TestSingletonInitialisation(t *testing.T) {
-	t.Run("errors if LAUNCHDARKLY_CONFIGURATION is not present in environment", func(t *testing.T) {
-		err := flags.Configure()
+	t.Run(fmt.Sprintf("errors if %s is not present in environment", configurationEnvVar), func(t *testing.T) {
+		err := Configure()
 		require.Error(t, err)
 
-		_, err = flags.GetDefaultClient()
+		_, err = GetDefaultClient()
 		require.Error(t, err)
 	})
 
 	t.Run("does not error if SDK key supplied as env var", func(t *testing.T) {
-		os.Setenv("LAUNCHDARKLY_CONFIGURATION", "{\"sdkKey\": \"abc\"}")
-		defer os.Unsetenv("LAUNCHDARKLY_CONFIGURATION")
-		err := flags.Configure()
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+		err := Configure()
 		require.NoError(t, err)
 	})
 }

--- a/x/launchdarkly/flags/flags_test.go
+++ b/x/launchdarkly/flags/flags_test.go
@@ -1,17 +1,15 @@
 package flags_test
 
 import (
-	"net/url"
 	"os"
 	"testing"
-	"time"
 
 	"github.com/cultureamp/ca-go/x/launchdarkly/flags"
 	"github.com/stretchr/testify/require"
 )
 
-func TestInitialisationSingleton(t *testing.T) {
-	t.Run("errors if an SDK key is not supplied", func(t *testing.T) {
+func TestSingletonInitialisation(t *testing.T) {
+	t.Run("errors if LAUNCHDARKLY_CONFIGURATION is not present in environment", func(t *testing.T) {
 		err := flags.Configure()
 		require.Error(t, err)
 
@@ -20,70 +18,9 @@ func TestInitialisationSingleton(t *testing.T) {
 	})
 
 	t.Run("does not error if SDK key supplied as env var", func(t *testing.T) {
-		os.Setenv("LAUNCHDARKLY_SDK_KEY", "foobar")
-		defer os.Unsetenv("LAUNCHDARKLY_SDK_KEY")
+		os.Setenv("LAUNCHDARKLY_CONFIGURATION", "{\"sdkKey\": \"abc\"}")
+		defer os.Unsetenv("LAUNCHDARKLY_CONFIGURATION")
 		err := flags.Configure()
 		require.NoError(t, err)
-	})
-
-	t.Run("does not error if SDK key supplied as config option", func(t *testing.T) {
-		err := flags.Configure(flags.WithSDKKey("foobar"))
-		require.NoError(t, err)
-	})
-
-	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {
-		err := flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithInitWait(2*time.Second))
-		require.NoError(t, err)
-	})
-
-	t.Run("allows a Relay Proxy URL to be specified", func(t *testing.T) {
-		proxyURL, err := url.Parse("http://localhost:8030")
-		require.NoError(t, err)
-
-		err = flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithProxyMode(proxyURL))
-		require.NoError(t, err)
-	})
-
-	t.Run("allows daemon mode to be configured", func(t *testing.T) {
-		err := flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-		)
-		require.NoError(t, err)
-	})
-
-	t.Run("allows daemon mode to be configured with an alternate Dynamo base URL", func(t *testing.T) {
-		baseURL, err := url.Parse("http://localhost:6789")
-		require.NoError(t, err)
-
-		err = flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-			flags.WithDynamoBaseURL(baseURL),
-		)
-		require.NoError(t, err)
-
-		err = flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithDynamoBaseURL(baseURL),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-		)
-		require.NoError(t, err, "should not error when base URL provided before Dynamo table")
-	})
-
-	t.Run("does not allow both proxy and daemon modes", func(t *testing.T) {
-		proxyURL, err := url.Parse("http://localhost:8030")
-		require.NoError(t, err)
-
-		err = flags.Configure(
-			flags.WithSDKKey("foobar"),
-			flags.WithDaemonMode("dynamo-table-name", 10*time.Second),
-			flags.WithProxyMode(proxyURL),
-		)
-		require.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Purpose
The Ruby Wrapper was updated while being used to deploy to prod and some improvements were identified. To match this wrapper, the go wrapper also needs to be updated. This PR changes the following:

- FromEnvironment() should be the default configuration option for a client
- A uuid should be used as the key for an anonymous user rather than a hardcoded string as this allows the targeting of users before they are logged in
- Update unit tests to work with new implementation

## Context
Please see the following [PR](https://github.com/cultureamp/ca-feature_flags-ruby/pull/10 - Connect to preview)[https://github.com/cultureamp/ca-feature_flags-ruby/pull/10 - Connect to preview](https://github.com/cultureamp/ca-feature_flags-ruby/pull/10) for the Ruby Wrapper updates
