### PR TITLE
feat: allow config overrides for Proxy and Lambda modes

### DIFF
--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -17,6 +17,10 @@ type Client struct {
 	mode          mode
 	wrappedConfig ld.Config
 	wrappedClient *ld.LDClient
+
+	// Optional config overrides.
+	proxyModeConfig  *ProxyModeConfig
+	lambdaModeConfig *LambdaModeConfig
 }
 
 // The mode the SDK should be configured for.
@@ -47,11 +51,11 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 	}
 
 	if parsedConfig.Options.Proxy != nil && c.mode == modeProxy {
-		c.wrappedConfig = configForProxyMode(parsedConfig.Options.Proxy)
+		c.wrappedConfig = configForProxyMode(parsedConfig, c.proxyModeConfig)
 	}
 
 	if parsedConfig.Options.DaemonMode != nil && c.mode == modeLambda {
-		c.wrappedConfig = configForLambdaMode(parsedConfig.Options.DaemonMode)
+		c.wrappedConfig = configForLambdaMode(parsedConfig, c.lambdaModeConfig)
 	}
 
 	return c, nil

--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -9,6 +9,10 @@
 // in can be retrieved from the AWS Secrets Manager under the key
 // `/common/launchdarkly-ops/sdk-configuration/<farm>`.
 //
+// You can provide overrides for some of the properties of LAUNCHDARKLY_CONFIGURATION.
+// Refer to the documentation for the WithProxyMode and WithLambdaMode options in
+// config.go.
+//
 // The client can be configured and used as a managed singleton or as an
 // instance returned from a constructor function. The managed singleton provides
 // a layer of convenience by removing the need for your application to maintain


### PR DESCRIPTION
Modifies how the final configuration for the Proxy and Lambda modes are
constructed so the user is able to supply configuration overrides via
ConfigOption arguments to the NewClient() function. The "base"
configuration is sourced from the LAUNCHDARKLY_CONFIGURATION environment
variable and provides a sensible default for most users. Users with
specific needs can opt to force the client into a specific mode, and
supply relevant configuration overrides for those modes.

For example, the WithProxyMode() function allows the user to specify an
alternate URL for the Relay Proxy (different from the one we specify in
the environment variable). WithLambdaMode() allows the user to configure
the client to connect directly to a DynamoDB table, and customise the
cache TTL and Dynamo base URL as necessary.