### PR TITLE
feat: allow the LD client to be configured in test mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,7 @@ run:
 linters:
   enable-all: true
   disable:
+  - gofumpt
   - gochecknoglobals
   - wrapcheck
   - varnamelen

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,13 @@ require (
 )
 
 require (
+	github.com/fsnotify/fsnotify v1.4.7 // indirect
+	golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 // indirect
+	gopkg.in/ghodss/yaml.v1 v1.0.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+)
+
+require (
 	github.com/aws/aws-lambda-go v1.28.0
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getsentry/sentry-go v0.11.0 h1:qro8uttJGvNAMr5CLcFI9CHR0aDzXl0Vs3Pmw/oTPg8=
@@ -142,6 +143,8 @@ golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9 h1:nhht2DYV/Sn3qOayu8lM+cU1ii9sTLUeBQwQQfUHtrs=
+golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
@@ -155,6 +158,7 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
+gopkg.in/ghodss/yaml.v1 v1.0.0 h1:JlY4R6oVz+ZSvcDhVfNQ/k/8Xo6yb2s1PBhslPZPX4c=
 gopkg.in/ghodss/yaml.v1 v1.0.0/go.mod h1:HDvRMPQLqycKPs9nWLuzZWxsxRzISLCRORiDpBUOMqg=
 gopkg.in/go-playground/assert.v1 v1.2.1/go.mod h1:9RXL0bg/zibRAgZUYszZSwO/z8Y/a8bDuhia5mkpMnE=
 gopkg.in/go-playground/validator.v8 v8.18.2/go.mod h1:RX2a/7Ha8BgOhfk7j780h4/u/RRjR0eouCJSH80/M2Y=
@@ -179,6 +183,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cultureamp/ca-go/x/launchdarkly/flags/evaluationcontext"
 	ld "gopkg.in/launchdarkly/go-server-sdk.v5"
+	"gopkg.in/launchdarkly/go-server-sdk.v5/testhelpers/ldtestdata"
 )
 
 // Client is a wrapper around the LaunchDarkly client.
@@ -17,6 +19,8 @@ type Client struct {
 	mode          mode
 	wrappedConfig ld.Config
 	wrappedClient *ld.LDClient
+
+	testModeConfig *TestModeConfig
 
 	// Optional config overrides.
 	proxyModeConfig  *ProxyModeConfig
@@ -29,6 +33,7 @@ type mode int
 const (
 	modeProxy  mode = iota // proxies requests through the LD Relay.
 	modeLambda             // connects directly to DynamoDB.
+	modeTest               // allows test data to be supplied.
 )
 
 // NewClient configures and returns an instance of the client. An
@@ -39,16 +44,29 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 		mode:     modeProxy,       // defaults to proxying requests through the LD Relay.
 	}
 
+	for _, opt := range opts {
+		opt(c)
+	}
+
+	// Use test mode if LAUNCHDARKLY_CONFIGURATION isn't set OR if the user
+	// explicitly configured the client for test mode.
+	if _, ok := os.LookupEnv(configurationEnvVar); !ok || c.mode == modeTest {
+		c.mode = modeTest
+		if c.testModeConfig == nil {
+			c.testModeConfig = &TestModeConfig{}
+		}
+		c.wrappedConfig = configForTestMode(c.testModeConfig)
+
+		// Short-circuit the rest of the configuration.
+		return c, nil
+	}
+
 	parsedConfig, err := configFromEnvironment()
 	if err != nil {
 		return nil, fmt.Errorf("configure from environment variable: %w", err)
 	}
 
 	c.sdkKey = parsedConfig.SDKKey
-
-	for _, opt := range opts {
-		opt(c)
-	}
 
 	if parsedConfig.Options.Proxy != nil && c.mode == modeProxy {
 		c.wrappedConfig = configForProxyMode(parsedConfig, c.proxyModeConfig)
@@ -146,4 +164,16 @@ func (c *Client) RawClient() interface{} {
 // connections and flush any flag evaluation events.
 func (c *Client) Shutdown() error {
 	return c.wrappedClient.Close()
+}
+
+// TestDataSource returns the test data source used by the client, or an
+// error if the client wasn't configured in test mode. See
+// https://docs.launchdarkly.com/sdk/features/test-data-sources for more
+// information on using the test data source.
+func (c *Client) TestDataSource() (*ldtestdata.TestDataSource, error) {
+	if c.testModeConfig == nil || c.testModeConfig.datasource == nil {
+		return nil, errors.New("client not initialised with test data source")
+	}
+
+	return c.testModeConfig.datasource, nil
 }

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -36,8 +36,10 @@ const (
 	modeTest               // allows test data to be supplied.
 )
 
-// NewClient configures and returns an instance of the client. An
-// error is returned if unable to configure from environment variable
+// NewClient configures and returns an instance of the client. The client is
+// configured automatically from the LAUNCHDARKLY_CONFIGURATION environment
+// variable if it exists. Otherwise, the client falls back to test mode. See
+// launchdarkly/flags/doc.go for more information.
 func NewClient(opts ...ConfigOption) (*Client, error) {
 	c := &Client{
 		initWait: 5 * time.Second, // wait up to 5 seconds for LD to connect.
@@ -166,13 +168,16 @@ func (c *Client) Shutdown() error {
 	return c.wrappedClient.Close()
 }
 
-// TestDataSource returns the test data source used by the client, or an
-// error if the client wasn't configured in test mode. See
-// https://docs.launchdarkly.com/sdk/features/test-data-sources for more
-// information on using the test data source.
+// TestDataSource returns the dynamic test data source used by the client, or an
+// error if:
+// - the client wasn't configured in test mode.
+// - the client was configured to read test data from a JSON file.
+//
+// See https://docs.launchdarkly.com/sdk/features/test-data-sources for more
+// information on using the test data source returned by this method.
 func (c *Client) TestDataSource() (*ldtestdata.TestDataSource, error) {
 	if c.testModeConfig == nil || c.testModeConfig.datasource == nil {
-		return nil, errors.New("client not initialised with test data source")
+		return nil, errors.New("client not initialised with dynamic test data source")
 	}
 
 	return c.testModeConfig.datasource, nil

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -27,7 +27,7 @@ const validConfigJSON = `
 }
 `
 
-func TestInitialisationClient(t *testing.T) {
+func TestClientTestMode(t *testing.T) {
 	t.Run("configures for Test mode if LAUNCHDARKLY_CONFIGURATION is not set", func(t *testing.T) {
 		c, err := NewClient()
 		require.NoError(t, err)
@@ -48,7 +48,7 @@ func TestInitialisationClient(t *testing.T) {
 		assert.Equal(t, false, res)
 	})
 
-	t.Run("configures for Test mode when explicitly told to", func(t *testing.T) {
+	t.Run("configures for Test mode with data set at runtime", func(t *testing.T) {
 		c, err := NewClient(WithTestMode(nil))
 		require.NoError(t, err)
 
@@ -68,7 +68,7 @@ func TestInitialisationClient(t *testing.T) {
 		assert.Equal(t, false, res)
 	})
 
-	t.Run("configures for Test mode with a JSON file data source", func(t *testing.T) {
+	t.Run("configures for Test mode data sourced from a local JSON file", func(t *testing.T) {
 		jsonFilename, err := ioutil.TempFile("", "test-flags.json")
 		require.NoError(t, err)
 
@@ -100,17 +100,9 @@ func TestInitialisationClient(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 3, res3)
 	})
+}
 
-	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {
-		os.Setenv(configurationEnvVar, validConfigJSON)
-		defer os.Unsetenv(configurationEnvVar)
-
-		client, err := NewClient(
-			WithInitWait(2 * time.Second))
-		require.NoError(t, err)
-		assert.Equal(t, client.initWait, 2*time.Second)
-	})
-
+func TestClientLambdaMode(t *testing.T) {
 	t.Run("configures for Lambda (daemon) mode", func(t *testing.T) {
 		os.Setenv(configurationEnvVar, validConfigJSON)
 		defer os.Unsetenv(configurationEnvVar)
@@ -141,6 +133,18 @@ func TestInitialisationClient(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, client.wrappedClient.GetDataStoreStatusProvider().GetStatus().Available)
+	})
+}
+
+func TestClientInitialisation(t *testing.T) {
+	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+
+		client, err := NewClient(
+			WithInitWait(2 * time.Second))
+		require.NoError(t, err)
+		assert.Equal(t, client.initWait, 2*time.Second)
 	})
 
 	t.Run("configures for Proxy mode", func(t *testing.T) {

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -1,10 +1,12 @@
 package flags
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/cultureamp/ca-go/x/launchdarkly/flags/evaluationcontext"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,9 +28,77 @@ const validConfigJSON = `
 `
 
 func TestInitialisationClient(t *testing.T) {
-	t.Run("errors if an SDK key is not supplied", func(t *testing.T) {
-		_, err := NewClient()
-		require.Error(t, err)
+	t.Run("configures for Test mode if LAUNCHDARKLY_CONFIGURATION is not set", func(t *testing.T) {
+		c, err := NewClient()
+		require.NoError(t, err)
+
+		require.NoError(t, c.Connect())
+
+		td, err := c.TestDataSource()
+		require.NoError(t, err)
+
+		td.Update(td.Flag("test-flag").VariationForAllUsers(true))
+		res, err := c.QueryBoolWithEvaluationContext("test-flag", evaluationcontext.NewAnonymousUser(""), false)
+		require.NoError(t, err)
+		assert.Equal(t, true, res)
+
+		td.Update(td.Flag("test-flag").VariationForAllUsers(false))
+		res, err = c.QueryBoolWithEvaluationContext("test-flag", evaluationcontext.NewAnonymousUser(""), true)
+		require.NoError(t, err)
+		assert.Equal(t, false, res)
+	})
+
+	t.Run("configures for Test mode when explicitly told to", func(t *testing.T) {
+		c, err := NewClient(WithTestMode(nil))
+		require.NoError(t, err)
+
+		require.NoError(t, c.Connect())
+
+		td, err := c.TestDataSource()
+		require.NoError(t, err)
+
+		td.Update(td.Flag("test-flag").VariationForAllUsers(true))
+		res, err := c.QueryBoolWithEvaluationContext("test-flag", evaluationcontext.NewAnonymousUser(""), false)
+		require.NoError(t, err)
+		assert.Equal(t, true, res)
+
+		td.Update(td.Flag("test-flag").VariationForAllUsers(false))
+		res, err = c.QueryBoolWithEvaluationContext("test-flag", evaluationcontext.NewAnonymousUser(""), true)
+		require.NoError(t, err)
+		assert.Equal(t, false, res)
+	})
+
+	t.Run("configures for Test mode with a JSON file data source", func(t *testing.T) {
+		jsonFilename, err := ioutil.TempFile("", "test-flags.json")
+		require.NoError(t, err)
+
+		_, err = jsonFilename.Write([]byte(`
+		{
+			"flagValues": {
+			  "my-string-flag-key": "value-1",
+			  "my-boolean-flag-key": true,
+			  "my-integer-flag-key": 3
+			}
+		}	
+		`))
+		require.NoError(t, err)
+
+		c, err := NewClient(WithTestMode(&TestModeConfig{FlagFilename: jsonFilename.Name()}))
+		require.NoError(t, err)
+
+		require.NoError(t, c.Connect())
+
+		res, err := c.QueryStringWithEvaluationContext("my-string-flag-key", evaluationcontext.NewAnonymousUser(""), "value-2")
+		require.NoError(t, err)
+		assert.Equal(t, "value-1", res)
+
+		res2, err := c.QueryBoolWithEvaluationContext("my-boolean-flag-key", evaluationcontext.NewAnonymousUser(""), false)
+		require.NoError(t, err)
+		assert.Equal(t, true, res2)
+
+		res3, err := c.QueryIntWithEvaluationContext("my-integer-flag-key", evaluationcontext.NewAnonymousUser(""), 1)
+		require.NoError(t, err)
+		assert.Equal(t, 3, res3)
 	})
 
 	t.Run("allows an initialisation wait time to be specified", func(t *testing.T) {

--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -13,6 +13,14 @@
 // Refer to the documentation for the WithProxyMode and WithLambdaMode options in
 // config.go.
 //
+// If the LAUNCHDARKLY_CONFIGURATION variable does not exist, the SDK will fall-back
+// to test mode. Test mode disables connections to LaunchDarkly and allows you to
+// specify your own values for flags. By default, it attempts to find a file named
+// .ld-flags.json in the directory that you invoked your Go program from. Failing
+// this, it configures the SDK to use dynamic test data sourced at runtime. You can
+// also specify your own path to a JSON file to source flag data from. See
+// WithTestMode() in config.go for more information.
+//
 // The client can be configured and used as a managed singleton or as an
 // instance returned from a constructor function. The managed singleton provides
 // a layer of convenience by removing the need for your application to maintain

--- a/x/launchdarkly/flags/flags_test.go
+++ b/x/launchdarkly/flags/flags_test.go
@@ -1,7 +1,6 @@
 package flags
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -9,14 +8,6 @@ import (
 )
 
 func TestSingletonInitialisation(t *testing.T) {
-	t.Run(fmt.Sprintf("errors if %s is not present in environment", configurationEnvVar), func(t *testing.T) {
-		err := Configure()
-		require.Error(t, err)
-
-		_, err = GetDefaultClient()
-		require.Error(t, err)
-	})
-
 	t.Run("does not error if SDK key supplied as env var", func(t *testing.T) {
 		os.Setenv(configurationEnvVar, validConfigJSON)
 		defer os.Unsetenv(configurationEnvVar)


### PR DESCRIPTION
This PR enables test mode for the LaunchDarkly SDK. Test mode allows users of the SDK to supply fixed values for flag queries. It's useful for local development, testing, and CI. 

The changes made here allow the SDK to transparently fallback to test mode if the `LAUNCHDARKLY_CONFIGURATION` env var isn't present, or if explicitly told to via the `WithTestMode()` ConfigOption.