### PR TITLE
Use plain push instead of pull_request_target

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,12 +1,6 @@
 name: pipeline
 on:
-  # use PR target to allow for forks
-  pull_request_target:
-
-  # run on push to main so coverage is generated
   push:
-    branches:
-      - "main"
 
 env:
   GO_VERSION: 1.18


### PR DESCRIPTION
This didn't work like I thought, the actual checkout is of the base branch. This basically makes sense now, but I didn't understand that at the time.

Changing to simple push for now: another strategy might be needed in the future.