### PR TITLE
Enable Coveralls comments

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,10 @@
 name: pipeline
 on:
   push:
+    branches:
+      - main
+
+  pull_request:
 
 env:
   GO_VERSION: 1.18
@@ -64,5 +68,3 @@ jobs:
       - uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: artifacts/count.out
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}


### PR DESCRIPTION
Triggers using the `pull_request` event for non-main branches. The `pull_request` event provides the PR URL as one of the event parameters, something Coveralls needs to be able to comment on the PR.

Also, the `COVERALLS_TOKEN` isn't required for the push to work: these are only required for private repos.