### PR TITLE
Don't raise when local Sentry DSN missing

### DIFF
--- a/x/sentry/errorreport/errorreport.go
+++ b/x/sentry/errorreport/errorreport.go
@@ -27,7 +27,7 @@ func Init(opts ...Option) error {
 		missingMandatoryConfigs = append(missingMandatoryConfigs, "environment")
 	}
 
-	if cfg.dsn == "" {
+	if cfg.dsn == "" && cfg.environment != "local" {
 		missingMandatoryConfigs = append(missingMandatoryConfigs, "DSN")
 	}
 

--- a/x/sentry/errorreport/errorreport_test.go
+++ b/x/sentry/errorreport/errorreport_test.go
@@ -72,6 +72,14 @@ func TestConfigure(t *testing.T) {
 		require.EqualError(t, err, "mandatory fields missing: DSN")
 	})
 
+	t.Run("No error when DSN is missing, but environment is local", func(t *testing.T) {
+		err := errorreport.Init(
+			errorreport.WithEnvironment("local"),
+			errorreport.WithRelease("my-app", "1.0.0"),
+		)
+		require.NoError(t, err)
+	})
+
 	t.Run("errors when release is missing", func(t *testing.T) {
 		err := errorreport.Init(
 			errorreport.WithEnvironment("test"),


### PR DESCRIPTION
Currently we have to specify a Sentry DSN when running our apps locally. This change allows us to skip the DSN, essentially disabling it:

https://pkg.go.dev/github.com/getsentry/sentry-go#ClientOptions

We do want to avoid accidentally doing this outside of local though, hence the environment check.