### PR TITLE
Allow arbitrary tags in error reports

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -50,3 +50,6 @@ linters-settings:
         audit: disabled
       G101: # "Look for hard-coded credentials"
         mode: strict
+
+  cyclop:
+    max-complexity: 15 # the default of 10 was unnecessarily strict

--- a/x/sentry/errorreport/config.go
+++ b/x/sentry/errorreport/config.go
@@ -18,6 +18,8 @@ type config struct {
 	transport    sentry.Transport
 }
 
+// tag adds the specified name/value pair to the tags map, skipping any where
+// the key or the value is zero-length.
 func (c *config) tag(name string, value string) {
 	if len(name) > 0 && len(value) > 0 {
 		c.tags[name] = value

--- a/x/sentry/errorreport/config.go
+++ b/x/sentry/errorreport/config.go
@@ -12,13 +12,16 @@ type config struct {
 	release     string
 	debug       bool
 
-	buildNumber string
-	branch      string
-	commit      string
-	farm        string
+	tags map[string]string
 
 	beforeFilter SentryBeforeFilter
 	transport    sentry.Transport
+}
+
+func (c *config) tag(name string, value string) {
+	if len(name) > 0 && len(value) > 0 {
+		c.tags[name] = value
+	}
 }
 
 // Option is a function type that can be provided to Configure to modify the
@@ -90,9 +93,31 @@ func WithServerlessTransport() Option {
 // error reports.
 func WithBuildDetails(farm, buildNumber, branch, commit string) Option {
 	return func(c *config) {
-		c.farm = farm
-		c.buildNumber = buildNumber
-		c.branch = branch
-		c.commit = commit
+		c.tag("farm", farm)
+		c.tag("build_number", buildNumber)
+		c.tag("branch", branch)
+		c.tag("commit", commit)
+	}
+}
+
+// WithTag adds the specified name/value pair as a tag on every error report.
+// Tags are used for grouping and searching error reports.
+func WithTag(name string, value string) Option {
+	return func(c *config) {
+		c.tag(name, value)
+	}
+}
+
+// WithTag adds multiple name/value pairs as tags on every error report. Tags
+// are used for grouping and searching error reports.
+func WithTags(tags map[string]string) Option {
+	return func(c *config) {
+		if tags == nil {
+			return
+		}
+
+		for name, value := range tags {
+			c.tag(name, value)
+		}
 	}
 }

--- a/x/sentry/errorreport/errorreport.go
+++ b/x/sentry/errorreport/errorreport.go
@@ -16,7 +16,9 @@ const (
 // Init initialises the Sentry client with the given options. It returns
 // an error if mandatory options are not supplied.
 func Init(opts ...Option) error {
-	cfg := &config{}
+	cfg := &config{
+		tags: make(map[string]string),
+	}
 	for _, opt := range opts {
 		opt(cfg)
 	}
@@ -61,10 +63,9 @@ func Init(opts ...Option) error {
 	// Add build information to the scope for all error reports.
 	// This can't be done before we initialise the Sentry client.
 	sentry.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetTag("build_number", cfg.buildNumber)
-		scope.SetTag("branch", cfg.branch)
-		scope.SetTag("commit", cfg.commit)
-		scope.SetTag("farm", cfg.farm)
+		if cfg.tags != nil {
+			scope.SetTags(cfg.tags)
+		}
 	})
 
 	return nil

--- a/x/sentry/errorreport/lambda_example_test.go
+++ b/x/sentry/errorreport/lambda_example_test.go
@@ -44,6 +44,15 @@ func Example() {
 		errorreport.WithEnvironment(settings.AppEnv),
 		errorreport.WithBuildDetails(settings.Farm, buildNumber, branch, commit),
 		errorreport.WithServerlessTransport(),
+
+		// optionally add a tag to every error report
+		errorreport.WithTag("animal", "gopher"),
+
+		// or add multiple tags at once to be added to every error report
+		errorreport.WithTags(map[string]string{
+			"genus":   "phoenicoparrus",
+			"species": "jamesi",
+		}),
 	)
 	if err != nil {
 		// FIX: write error to log

--- a/x/sentry/errorreport/mocks_test.go
+++ b/x/sentry/errorreport/mocks_test.go
@@ -10,15 +10,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func setupMockSentryTransport(t *testing.T) *transportMock {
+func setupMockSentryTransport(t *testing.T, opts ...errorreport.Option) *transportMock {
 	t.Helper()
 
 	mockSentryTransport := &transportMock{}
-	err := errorreport.Init(
+
+	defaultOpts := []errorreport.Option{
 		errorreport.WithEnvironment("test"),
 		errorreport.WithDSN("https://public@sentry.example.com/1"),
 		errorreport.WithRelease("my-app", "1.0.0"),
-		errorreport.WithTransport(mockSentryTransport),
+	}
+
+	allOpts := make([]errorreport.Option, 0, len(defaultOpts)+len(opts)+1)
+
+	// merge default options with user-supplied options, ensuring that the transport is the last option
+	allOpts = append(allOpts, defaultOpts...)
+	allOpts = append(allOpts, opts...)
+	allOpts = append(allOpts, errorreport.WithTransport(mockSentryTransport))
+
+	err := errorreport.Init(
+		allOpts...,
 	)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Enables additional tags to be added as part of initial configuration. These tags will be included in every report, and can be used in Sentry for grouping and searching.

For example, you can add tags singly:

```go
errorreport.WithTag("animal", "gopher"),
```

Or many in one go:

```go
errorreport.WithTags(map[string]string{
	"genus":   "phoenicoparrus",
	"species": "jamesi",
}),
```

As a side effect, this change stops adding empty values for the build details fields (`farm`, `buildNumber`, `branch`, `commit`). The empty values were being added as a side-effect of using the library, regardless of the intent of the user. Not all processes will use `farm` (a Culture Amp concept), so an empty value will just be unwanted clutter.