### PR TITLE
COSE-90 Add support for targeting surveys in LaunchDarkly

### DIFF
--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -75,7 +75,9 @@
 //
 //   val, err := client.QueryBoolWithEvaluationContext("my-flag", user, false)
 //
-// When your application is shutting down, you should call Shutdown() to gracefully
-// close connections to LaunchDarkly:
+// You will not need to manually shut down your SDK in most situations. If you
+// know your application is about to terminate, or if you're testing an app,
+// you should manually Shutdown() the LaunchDarkly client before quitting to ensure
+// it delivers any pending analytics events to LaunchDarkly:
 //   client.Shutdown()
 package flags

--- a/x/launchdarkly/flags/evaluationcontext/doc.go
+++ b/x/launchdarkly/flags/evaluationcontext/doc.go
@@ -17,9 +17,4 @@
 // attributes as you can to give yourself more flexibility when writing new
 // targeting rules. When you query a flag containing a rule that works on
 // attribute "foo", you must supply attribute "foo" in the evaluation context.
-//
-// The constructor functions will namespace the key of the evaluation context
-// you send in the query. You do not need to prefix the values provided to
-// the constructor functions with the entity type. For example, supply the user
-// ID as-is rather than prefixing as `user.<user-id>`.
 package evaluationcontext

--- a/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
+++ b/x/launchdarkly/flags/evaluationcontext/evaluationcontext.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Context represents a set of attributes which a flag is evaluated against. The
-// only context supported now is User.
+// only contexts supported now are User and Survey
 type Context interface {
 	// ToLDUser transforms the context implementation into an LDUser object that can
 	// be understood by LaunchDarkly when evaluating a flag.

--- a/x/launchdarkly/flags/evaluationcontext/survey.go
+++ b/x/launchdarkly/flags/evaluationcontext/survey.go
@@ -1,0 +1,41 @@
+package evaluationcontext
+
+import (
+	"gopkg.in/launchdarkly/go-sdk-common.v2/lduser"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
+)
+
+const (
+	surveyAttributeSurveyID = "surveyID"
+)
+
+// Survey is a type of context, representing the identifiers and attributes of
+// a human user to evaluate a flag against.
+type Survey struct {
+	key      string
+	surveyID string
+
+	ldUser lduser.User
+}
+
+func (u Survey) ToLDUser() lduser.User {
+	return u.ldUser
+}
+
+// NewSurvey returns a new user object with the given survey ID, there are no options.
+// surveyID is the ID of the currently authenticated survey, and will generally
+// be a "survey_aggregate_id".
+func NewSurvey(surveyID string) Survey {
+	u := &Survey{
+		key:      surveyID,
+		surveyID: surveyID,
+	}
+
+	userBuilder := lduser.NewUserBuilder(u.key)
+	userBuilder.Custom(
+		surveyAttributeSurveyID,
+		ldvalue.String(u.surveyID))
+	u.ldUser = userBuilder.Build()
+
+	return *u
+}

--- a/x/launchdarkly/flags/evaluationcontext/survey.go
+++ b/x/launchdarkly/flags/evaluationcontext/survey.go
@@ -10,7 +10,7 @@ const (
 )
 
 // Survey is a type of context, representing the identifiers and attributes of
-// a human user to evaluate a flag against.
+// a survey to evaluate a flag against.
 type Survey struct {
 	key      string
 	surveyID string
@@ -22,7 +22,7 @@ func (u Survey) ToLDUser() lduser.User {
 	return u.ldUser
 }
 
-// NewSurvey returns a new user object with the given survey ID, there are no options.
+// NewSurvey returns a new Survey object with the given survey ID, there are no options.
 // surveyID is the ID of the currently authenticated survey, and will generally
 // be a "survey_aggregate_id".
 func NewSurvey(surveyID string) Survey {

--- a/x/launchdarkly/flags/evaluationcontext/survey_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/survey_test.go
@@ -1,0 +1,29 @@
+package evaluationcontext_test
+
+import (
+	"testing"
+
+	"github.com/cultureamp/ca-go/x/launchdarkly/flags/evaluationcontext"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSurvey(t *testing.T) {
+	t.Run("can create a survey", func(t *testing.T) {
+		survey := evaluationcontext.NewSurvey("not-a-uuid")
+		assertSurveyAttributes(t, survey, "not-a-uuid")
+
+		survey = evaluationcontext.NewSurvey(
+			"not-a-uuid",
+		)
+		assertSurveyAttributes(t, survey, "not-a-uuid")
+	})
+}
+
+func assertSurveyAttributes(t *testing.T, survey evaluationcontext.Survey, surveyID string) {
+	t.Helper()
+
+	ldUser := survey.ToLDUser()
+
+	assert.Equal(t, surveyID, ldUser.GetKey())
+	assert.Equal(t, surveyID, ldUser.GetAttribute("surveyID").StringValue())
+}

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	userAttributeUserID     = "userID"
 	userAttributeAccountID  = "accountID"
 	userAttributeRealUserID = "realUserID"
 )
@@ -19,6 +20,7 @@ const (
 // a human user to evaluate a flag against.
 type User struct {
 	key        string
+	userID     string
 	realUserID string
 	accountID  string
 
@@ -76,7 +78,8 @@ func NewAnonymousUser(key string) User {
 // be a "user_aggregate_id".
 func NewUser(userID string, opts ...UserOption) User {
 	u := &User{
-		key: userID,
+		key:    userID,
+		userID: userID,
 	}
 
 	for _, opt := range opts {
@@ -90,6 +93,9 @@ func NewUser(userID string, opts ...UserOption) User {
 	userBuilder.Custom(
 		userAttributeRealUserID,
 		ldvalue.String(u.realUserID))
+	userBuilder.Custom(
+		userAttributeUserID,
+		ldvalue.String(u.userID))
 	u.ldUser = userBuilder.Build()
 
 	return *u

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -55,8 +55,8 @@ func WithRealUserID(id string) UserOption {
 // NewAnonymousUser returns a user object suitable for use in unauthenticated
 // requests or requests with no access to user identifiers.
 // Provide a unique session or request identifier as the key if possible. If the
-// key is empty, it will default to 'ANONYMOUS_USER' and percentage rollouts
-// will not be supported.
+// key is empty, it will default to an uuid so percentage rollouts will still apply.
+// No userID will be given to an anonymous user.
 func NewAnonymousUser(key string) User {
 	if key == "" {
 		key = uuid.NewString()

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -19,7 +19,7 @@ func TestNewUser(t *testing.T) {
 
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
-		assertUserAttributes(t, user, "my-request-id", "", "")
+		assert.Equal(t, "my-request-id", user.ToLDUser().GetKey())
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {
@@ -55,12 +55,7 @@ func assertUserAttributes(t *testing.T, user evaluationcontext.User, userID, rea
 	ldUser := user.ToLDUser()
 
 	assert.Equal(t, userID, ldUser.GetKey())
-	// anonymous users will not have a userID
-	if ldUser.GetAnonymous() {
-		assert.Equal(t, "", ldUser.GetAttribute("userID").StringValue())
-	} else {
-		assert.Equal(t, userID, ldUser.GetAttribute("userID").StringValue())
-	}
+	assert.Equal(t, userID, ldUser.GetAttribute("userID").StringValue())
 	assert.Equal(t, realUserID, ldUser.GetAttribute("realUserID").StringValue())
 	assert.Equal(t, accountID, ldUser.GetAttribute("accountID").StringValue())
 }

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -55,6 +55,12 @@ func assertUserAttributes(t *testing.T, user evaluationcontext.User, userID, rea
 	ldUser := user.ToLDUser()
 
 	assert.Equal(t, userID, ldUser.GetKey())
+	// anonymous users will not have a userID
+	if ldUser.GetAnonymous() {
+		assert.Equal(t, "", ldUser.GetAttribute("userID").StringValue())
+	} else {
+		assert.Equal(t, userID, ldUser.GetAttribute("userID").StringValue())
+	}
 	assert.Equal(t, realUserID, ldUser.GetAttribute("realUserID").StringValue())
 	assert.Equal(t, accountID, ldUser.GetAttribute("accountID").StringValue())
 }


### PR DESCRIPTION
## Purpose
To get more flexibility out of the platform, our implementation should support evaluation contexts that map to entities other than human users. Some of our use cases revolve around the surveys domain, which can be its own evaluation context and be treated as a first-class citizen of the platform. This means we can target flags against segments of surveys.

## Context
In addition to adding survey evaluation context, this also introduces submission of userID and surveyID custom attributes with user and survey contexts respectively in order to provide an easy way of identifying type of context in LaunchDarkly UI.

This PR is consistent with the [Node](https://github.com/cultureamp/ca-launchdarkly-js/pull/68) and [Ruby](https://github.com/cultureamp/ca-launchdarkly-ruby/pull/33) Wrappers
[JIRA Ticket](https://cultureamp.atlassian.net/browse/COSE-90?atlOrigin=eyJpIjoiYThmZjY0OGZkNjQ0NGViYWFhOTZiN2M3NDVjMWQ3MTEiLCJwIjoiaiJ9)