### PR TITLE
add more sarama kafka config options to help testing

### DIFF
--- a/x/sarama/kafkaclient/kafka.go
+++ b/x/sarama/kafkaclient/kafka.go
@@ -2,9 +2,16 @@ package kafkaclient
 
 import (
 	"crypto/tls"
+	"log"
+	"os"
 
 	"github.com/Shopify/sarama"
 )
+
+// EnableDebugLog provides more details on how sarama connecting to brokers
+func EnableDebugLog() {
+	sarama.Logger = log.New(os.Stdout, "[sarama] ", log.LstdFlags)
+}
 
 // DefaultProducerConfiguration creates a Sarama configuration with the default settings
 // appropriate for use by a Sarama SyncProducer in a SASL environment.
@@ -35,6 +42,19 @@ func DefaultProducerConfiguration(clientID string, username string, password str
 	conf.Net.TLS.Config = &tls.Config{
 		MinVersion: tls.VersionTLS12,
 	}
+
+	return conf
+}
+
+// NonSSLProducerConfiguration creates a Sarama configuration with the default settings without SSL config
+// appropriate for use to test connection with local Kafka
+func NonSSLProducerConfiguration(clientID string) *sarama.Config {
+	conf := sarama.NewConfig()
+
+	conf.Producer.RequiredAcks = sarama.WaitForAll
+	conf.Producer.Return.Successes = true
+	conf.Producer.Return.Errors = true
+	conf.ClientID = clientID
 
 	return conf
 }

--- a/x/sarama/kafkaclient/kafka_test.go
+++ b/x/sarama/kafkaclient/kafka_test.go
@@ -56,3 +56,11 @@ func TestDefaultProducerConfiguration(t *testing.T) {
 	assert.True(t, config.Net.TLS.Enable)
 	assert.True(t, config.Net.SASL.Enable)
 }
+
+func TestNonSSLProducerConfiguration(t *testing.T) {
+	config := kafkaclient.NonSSLProducerConfiguration("test_client_tag")
+
+	assert.Equal(t, "test_client_tag", config.ClientID)
+	assert.False(t, config.Net.TLS.Enable)
+	assert.False(t, config.Net.SASL.Enable)
+}


### PR DESCRIPTION
## Purpose
Currently we only provide a default config which won't work with local Kafka. 

## Context
- Added a function to turn on sarama debug log to provide more details when connecting brokers failed
- Added a non-SSL config function to return sarama config that could be used for local Kafka
