### PR TITLE
[COSE-150] Add custom error report title

### DIFF
--- a/x/sentry/errorreport/errorreport_test.go
+++ b/x/sentry/errorreport/errorreport_test.go
@@ -120,6 +120,21 @@ func TestConfigure(t *testing.T) {
 	})
 }
 
+func TestConfigureWithBeforeFilter(t *testing.T) {
+	testingScope(t)
+	ctx := context.Background()
+	mockSentryTransport := setupMockSentryTransport(t,
+		errorreport.WithBeforeFilter(errorreport.RootCauseAsTitle),
+	)
+
+	errorreport.ReportError(ctx, errors.New("a flamingo"))
+
+	require.Len(t, mockSentryTransport.events, 1)
+
+	event := mockSentryTransport.events[0]
+	assert.Equal(t, "a flamingo", event.Exception[0].Type)
+}
+
 func TestConfigureWithTag(t *testing.T) {
 	testingScope(t)
 	ctx := context.Background()

--- a/x/sentry/errorreport/filter.go
+++ b/x/sentry/errorreport/filter.go
@@ -1,0 +1,12 @@
+package errorreport
+
+import "github.com/getsentry/sentry-go"
+
+// RootCauseAsTitle uses error message as custom exception type. The general errors like *erros.errorString can end up
+// grouping errors and makes it harder for us to find the latest error in Sentry issues dashboard.
+func RootCauseAsTitle(event *sentry.Event, hint *sentry.EventHint) *sentry.Event {
+	for i, exception := range event.Exception {
+		event.Exception[i].Type = exception.Value
+	}
+	return event
+}

--- a/x/sentry/errorreport/lambda_example_test.go
+++ b/x/sentry/errorreport/lambda_example_test.go
@@ -53,6 +53,9 @@ func Example() {
 			"genus":   "phoenicoparrus",
 			"species": "jamesi",
 		}),
+
+		// optionally customise error title with the root cause message
+		errorreport.WithBeforeFilter(errorreport.RootCauseAsTitle),
 	)
 	if err != nil {
 		// FIX: write error to log


### PR DESCRIPTION
# Purpose
Currently the Sentry error titles are pretty general, e.g. `*erros.errorString`. It ends up grouping errors and makes it harder for us to find the latest error in Sentry issues dashboard. We'd like to see what's the actual error from the title.

# Context

- Created RootCauseAsTitle which uses error message as custom exception type. 
- Pass it as param of `WithBeforeFilter` on errorreport init.