### PR TITLE
[COSE-319] Add secret manager fetching to ca-go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Current packages:
 - `launchdarkly/flags`: eases the implementation and usage of LaunchDarkly for feature flags, encapsulating usage patterns in Culture Amp
 - `request`: encapsulates the availability of request information on the request context
 - `sentry/errorreport`: eases the implementation and usage of Sentry for error reporting
+- `secrets`: provides methods for fetching secrets from AWS secret manager
 
 ## Context
 

--- a/x/secrets/doc.go
+++ b/x/secrets/doc.go
@@ -1,0 +1,3 @@
+// package secrets adds helper methods to fetch secrets from the AWS secret
+// manager.
+package secrets

--- a/x/secrets/doc.go
+++ b/x/secrets/doc.go
@@ -1,3 +1,14 @@
 // package secrets adds helper methods to fetch secrets from the AWS secret
-// manager.
+// manager for use in AWS lambdas.
+//
+// **Secrets should be fetched during the cold start of the lambda**
+//
+// To create the secret manager client:
+//
+// `secretClient, err := secrets.NewAWSSecretsClient(envConfig.AwsRegion)`
+//
+// then fetch the secret using Get:
+//
+// `secretValue, err = secretClient.Get("/your/secret-name")`
+//
 package secrets

--- a/x/secrets/secrets.go
+++ b/x/secrets/secrets.go
@@ -1,0 +1,45 @@
+package secrets
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+)
+
+type SecretClient interface {
+	Get(string) (string, error)
+}
+
+type AWSSecrets struct {
+	Client interface {
+		GetSecretValue(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+	}
+}
+
+func NewAWSSecretsClient(region string) (*AWSSecrets, error) {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	}))
+
+	client := secretsmanager.New(sess)
+	return &AWSSecrets{
+		Client: client,
+	}, nil
+}
+
+func (s *AWSSecrets) Get(secretName string) (string, error) {
+	input := &secretsmanager.GetSecretValueInput{
+		SecretId: aws.String(secretName),
+	}
+
+	result, err := s.Client.GetSecretValue(input)
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve %s: %w", secretName, err)
+	}
+	if result == nil || result.SecretString == nil {
+		return "", fmt.Errorf("retrieved secret %s is empty", secretName)
+	}
+	return *result.SecretString, nil
+}

--- a/x/secrets/secrets_test.go
+++ b/x/secrets/secrets_test.go
@@ -1,0 +1,63 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/secretsmanager"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAWSSecretsClient(t *testing.T) {
+	client, err := NewAWSSecretsClient("us-west-2")
+
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+	assert.NotNil(t, client.Client)
+}
+
+type MockClient struct {
+	get func(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error)
+}
+
+func (m MockClient) GetSecretValue(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+	return m.get(input)
+}
+
+func TestAWSSecretsGet(t *testing.T) {
+	var actualRequestedSecretName string
+	secretManager := AWSSecrets{
+		Client: MockClient{
+			get: func(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+				actualRequestedSecretName = *input.SecretId
+
+				return &secretsmanager.GetSecretValueOutput{
+					SecretString: aws.String("my-super-secret-value"),
+				}, nil
+			},
+		},
+	}
+
+	secretString, err := secretManager.Get("my-secret-name")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "my-super-secret-value", secretString)
+	assert.Equal(t, "my-secret-name", actualRequestedSecretName)
+}
+
+func TestAWSSecretsGetEmptySecret(t *testing.T) {
+	secretManager := AWSSecrets{
+		Client: MockClient{
+			get: func(input *secretsmanager.GetSecretValueInput) (*secretsmanager.GetSecretValueOutput, error) {
+				return &secretsmanager.GetSecretValueOutput{
+					SecretString: nil,
+				}, nil
+			},
+		},
+	}
+
+	secretString, err := secretManager.Get("my-secret-name")
+
+	assert.Error(t, err)
+	assert.Equal(t, "", secretString)
+}


### PR DESCRIPTION
This PR extracts our secret fetching code out of the `accounts-service` and `fusionauth-hooks`. We are about to require this logic for the 3rd time, so thought it would be good to extract it out here.

This new package creates the secret manager client for a given region, and fetches the secret value given a secret name.