### PR TITLE
Add big segments configuration for lambda mode

### DIFF
--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -140,6 +140,8 @@ func configForProxyMode(env configurationJSON, cfg *ProxyModeConfig) ld.Config {
 func configForLambdaMode(env configurationJSON, cfg *LambdaModeConfig) ld.Config {
 	datastoreBuilder := lddynamodb.DataStore(env.Options.DaemonMode.DynamoTableName)
 
+	bigSegmentStore := ldcomponents.BigSegments(datastoreBuilder)
+
 	// Set the Dynamo base URL if one was provided explicitly.
 	if cfg != nil && cfg.DynamoBaseURL != "" {
 		datastoreBuilder.ClientConfig(aws.NewConfig().WithEndpoint(cfg.DynamoBaseURL))
@@ -155,8 +157,9 @@ func configForLambdaMode(env configurationJSON, cfg *LambdaModeConfig) ld.Config
 	}
 
 	return ld.Config{
-		DataSource: ldcomponents.ExternalUpdatesOnly(),
-		DataStore:  datastore,
+		DataSource:  ldcomponents.ExternalUpdatesOnly(),
+		DataStore:   datastore,
+		BigSegments: bigSegmentStore,
 	}
 }
 


### PR DESCRIPTION
By default, there is no configuration and Big Segments cannot be evaluated. In this
case, any flag evaluation that references a Big Segment will behave as if no users
are included in any Big Segments, and the EvaluationReason associated with any such
flag evaluation will return `ldreason.BigSegmentsStoreNotConfigured` from its
`GetBigSegmentsStatus()` method.