### PR TITLE
feat: configure big segments and use refined config structure

### DIFF
--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -70,12 +70,17 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 
 	c.sdkKey = parsedConfig.SDKKey
 
-	if parsedConfig.Options.Proxy != nil && c.mode == modeProxy {
+	if parsedConfig.Proxy != nil && c.mode == modeProxy {
 		c.wrappedConfig = configForProxyMode(parsedConfig, c.proxyModeConfig)
 	}
 
-	if parsedConfig.Options.DaemonMode != nil && c.mode == modeLambda {
+	if parsedConfig.Storage != nil && c.mode == modeLambda {
 		c.wrappedConfig = configForLambdaMode(parsedConfig, c.lambdaModeConfig)
+	}
+
+	// Configure big segments if the storage table name is present
+	if parsedConfig.Storage != nil && parsedConfig.Storage.TableName != "" {
+		c.wrappedConfig.BigSegments = configForBigSegments(parsedConfig).BigSegments
 	}
 
 	return c, nil

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -14,26 +14,24 @@ import (
 
 const validConfigJSON = `
 {
-    "sdkKey":"super-secret-key",
-    "options":{
-        "daemonMode":{
-            "dynamo_base_url":"url-here",
-            "DynamoTableName":"my-dynamo-table",
-            "dynamoCacheTTLSeconds":30
-        },
-        "proxyMode":{
-            "url":"https://relay-proxy.cultureamp.net"
-        }
-    }
+	"sdkKey":"super-secret-key",
+	"storage":{
+		"dynamo_base_url":"url-here",
+		"tableName":"my-dynamo-table",
+		"dynamoCacheTTLSeconds":30
+	},
+	"proxy":{
+		"url":"https://relay-proxy.cultureamp.net"
+	}
 }
 `
 
 const validFlagsJSON = `
 {
 	"flagValues": {
-	  "my-string-flag-key": "value-1",
-	  "my-boolean-flag-key": true,
-	  "my-integer-flag-key": 3
+		"my-string-flag-key": "value-1",
+		"my-boolean-flag-key": true,
+		"my-integer-flag-key": 3
 	}
 }
 `


### PR DESCRIPTION
The wrapper is now configured to get Big Segments data from the Relay Proxy persistent storage regardless of the connection mode. In order for us to actually support big segments, we need to connect our clients directly to the data table, and that requires DynamoDB `GetItem` permission on relay table.