### PR TITLE
[core-services] added new anonymous user with subdomain function for web gateway

### DIFF
--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -14,6 +14,7 @@ const (
 	userAttributeUserID     = "userID"
 	userAttributeAccountID  = "accountID"
 	userAttributeRealUserID = "realUserID"
+	userAttributeSubdomain  = "subdomain"
 )
 
 // User is a type of context, representing the identifiers and attributes of
@@ -62,15 +63,34 @@ func NewAnonymousUser(key string) User {
 		key = uuid.NewString()
 	}
 
-	u := User{
+	return User{
 		key: key,
+		ldUser: lduser.NewUserBuilder(key).
+			Anonymous(true).
+			Build(),
+	}
+}
+
+// NewAnonymousUserWithSubdomain returns a user object suitable for use in unauthenticated with known subdomain
+// requests or requests with no access to user identifiers.
+// Provide a unique session or request identifier as the key if possible. If the
+// key is empty, it will default to an uuid so percentage rollouts will still apply.
+// No userID will be given to an anonymous user.
+func NewAnonymousUserWithSubdomain(key string, subdomain string) User {
+	if key == "" {
+		key = uuid.NewString()
 	}
 
-	userBuilder := lduser.NewUserBuilder(u.key)
-	userBuilder.Anonymous(true)
-	u.ldUser = userBuilder.Build()
-
-	return u
+	return User{
+		key: key,
+		ldUser: lduser.NewUserBuilder(key).
+			Anonymous(true).
+			Custom(
+				userAttributeSubdomain,
+				ldvalue.String(subdomain),
+			).
+			Build(),
+	}
 }
 
 // NewUser returns a new user object with the given user ID and options.

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cultureamp/ca-go/x/request"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/launchdarkly/go-sdk-common.v2/ldvalue"
 )
 
 func TestNewUser(t *testing.T) {
@@ -20,6 +21,26 @@ func TestNewUser(t *testing.T) {
 	t.Run("can create an anonymous user with session/request key", func(t *testing.T) {
 		user := evaluationcontext.NewAnonymousUser("my-request-id")
 		assert.Equal(t, "my-request-id", user.ToLDUser().GetKey())
+	})
+
+	t.Run("can create an anonymous user with subdomain", func(t *testing.T) {
+		user := evaluationcontext.NewAnonymousUserWithSubdomain("", "cultureamp")
+		ldUser := user.ToLDUser()
+		assert.True(t, ldUser.GetAnonymous())
+
+		value, result := ldUser.GetCustom("subdomain")
+		assert.Equal(t, ldvalue.String("cultureamp"), value)
+		assert.True(t, result)
+	})
+
+	t.Run("can create an anonymous user with session/request key and subdomain", func(t *testing.T) {
+		user := evaluationcontext.NewAnonymousUserWithSubdomain("my-request-id", "cultureamp")
+		assert.Equal(t, "my-request-id", user.ToLDUser().GetKey())
+
+		ldUser := user.ToLDUser()
+		value, result := ldUser.GetCustom("subdomain")
+		assert.Equal(t, ldvalue.String("cultureamp"), value)
+		assert.True(t, result)
 	})
 
 	t.Run("can create an identified user", func(t *testing.T) {


### PR DESCRIPTION
Added new anonymous user with subdomain function for web-gateway

Similar to `NewAnonymousUser` function, we would like to capture user subdomain as one custom attribute so that devs can toggle the feature toggle to filter out anonymous user within a particular subdomain (e.g. `qastandard`)

