### PR TITLE
[core-services] fix LD initialisation issue

### DIFF
--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -14,11 +14,12 @@ import (
 
 // Client is a wrapper around the LaunchDarkly client.
 type Client struct {
-	sdkKey        string
-	initWait      time.Duration
-	mode          mode
-	wrappedConfig ld.Config
-	wrappedClient *ld.LDClient
+	sdkKey             string
+	initWait           time.Duration
+	mode               mode
+	bigSegmentsEnabled bool
+	wrappedConfig      ld.Config
+	wrappedClient      *ld.LDClient
 
 	testModeConfig *TestModeConfig
 
@@ -42,17 +43,28 @@ const (
 // launchdarkly/flags/doc.go for more information.
 func NewClient(opts ...ConfigOption) (*Client, error) {
 	c := &Client{
-		initWait: 5 * time.Second, // wait up to 5 seconds for LD to connect.
-		mode:     modeProxy,       // defaults to proxying requests through the LD Relay.
+		initWait:           5 * time.Second, // wait up to 5 seconds for LD to connect.
+		mode:               modeProxy,       // defaults to proxying requests through the LD Relay.
+		bigSegmentsEnabled: false,           // defaults to disable big segments
 	}
 
 	for _, opt := range opts {
 		opt(c)
 	}
 
+	parsedConfig := configurationJSON{}
+	_, ok := os.LookupEnv(configurationEnvVar)
+	if ok {
+		config, err := configFromEnvironment()
+		if err != nil {
+			return nil, fmt.Errorf("configure from environment variable: %w", err)
+		}
+		parsedConfig = config
+	}
+
 	// Use test mode if LAUNCHDARKLY_CONFIGURATION isn't set OR if the user
 	// explicitly configured the client for test mode.
-	if _, ok := os.LookupEnv(configurationEnvVar); !ok || c.mode == modeTest {
+	if !ok || c.mode == modeTest {
 		c.mode = modeTest
 		if c.testModeConfig == nil {
 			c.testModeConfig = &TestModeConfig{}
@@ -61,11 +73,6 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 
 		// Short-circuit the rest of the configuration.
 		return c, nil
-	}
-
-	parsedConfig, err := configFromEnvironment()
-	if err != nil {
-		return nil, fmt.Errorf("configure from environment variable: %w", err)
 	}
 
 	c.sdkKey = parsedConfig.SDKKey
@@ -79,7 +86,9 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 	}
 
 	// Configure big segments if the storage table name is present
-	if parsedConfig.Storage != nil && parsedConfig.Storage.TableName != "" {
+	if c.bigSegmentsEnabled &&
+		parsedConfig.Storage != nil &&
+		parsedConfig.Storage.TableName != "" {
 		c.wrappedConfig.BigSegments = configForBigSegments(parsedConfig).BigSegments
 	}
 

--- a/x/launchdarkly/flags/client.go
+++ b/x/launchdarkly/flags/client.go
@@ -45,7 +45,7 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 	c := &Client{
 		initWait:           5 * time.Second, // wait up to 5 seconds for LD to connect.
 		mode:               modeProxy,       // defaults to proxying requests through the LD Relay.
-		bigSegmentsEnabled: false,           // defaults to disable big segments
+		bigSegmentsEnabled: true,            // defaults to enable big segments
 	}
 
 	for _, opt := range opts {

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -210,4 +210,14 @@ func TestClientInitialisation(t *testing.T) {
 		assert.Equal(t, "https://foo.bar", client.wrappedConfig.ServiceEndpoints.Events)
 		assert.Equal(t, "https://foo.bar", client.wrappedConfig.ServiceEndpoints.Polling)
 	})
+
+	t.Run("allows big segments to be enabled", func(t *testing.T) {
+		os.Setenv(configurationEnvVar, validConfigJSON)
+		defer os.Unsetenv(configurationEnvVar)
+
+		client, err := NewClient(
+			WithBigSegmentEnabled())
+		require.NoError(t, err)
+		assert.Equal(t, client.bigSegmentsEnabled, true)
+	})
 }

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -211,13 +211,13 @@ func TestClientInitialisation(t *testing.T) {
 		assert.Equal(t, "https://foo.bar", client.wrappedConfig.ServiceEndpoints.Polling)
 	})
 
-	t.Run("allows big segments to be enabled", func(t *testing.T) {
+	t.Run("allows big segments to be disabled", func(t *testing.T) {
 		os.Setenv(configurationEnvVar, validConfigJSON)
 		defer os.Unsetenv(configurationEnvVar)
 
 		client, err := NewClient(
-			WithBigSegmentEnabled())
+			WithBigSegmentsDisabled())
 		require.NoError(t, err)
-		assert.Equal(t, client.bigSegmentsEnabled, true)
+		assert.Equal(t, client.bigSegmentsEnabled, false)
 	})
 }

--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -102,6 +102,12 @@ func WithTestMode(cfg *TestModeConfig) ConfigOption {
 	}
 }
 
+func WithBigSegmentEnabled() ConfigOption {
+	return func(c *Client) {
+		c.bigSegmentsEnabled = true
+	}
+}
+
 func configFromEnvironment() (configurationJSON, error) {
 	parsedConfig := configurationJSON{}
 

--- a/x/launchdarkly/flags/config.go
+++ b/x/launchdarkly/flags/config.go
@@ -102,9 +102,9 @@ func WithTestMode(cfg *TestModeConfig) ConfigOption {
 	}
 }
 
-func WithBigSegmentEnabled() ConfigOption {
+func WithBigSegmentsDisabled() ConfigOption {
 	return func(c *Client) {
-		c.bigSegmentsEnabled = true
+		c.bigSegmentsEnabled = false
 	}
 }
 

--- a/x/launchdarkly/flags/flags.go
+++ b/x/launchdarkly/flags/flags.go
@@ -16,19 +16,12 @@ func Configure(opts ...ConfigOption) error {
 		return fmt.Errorf("configure client: %w", err)
 	}
 
-	flagsClient = c
-	return nil
-}
-
-// Connect attempts to connect the managed singleton to LaunchDarkly. An error
-// is returned if the singleton is not yet configured, a connection has already
-// been established, or a connection error occurs.
-func Connect() error {
-	if flagsClient == nil {
-		return errClientNotConfigured
+	if err := c.Connect(); err != nil {
+		return fmt.Errorf("connect client: %w", err)
 	}
 
-	return flagsClient.Connect()
+	flagsClient = c
+	return nil
 }
 
 // GetDefaultClient returns the managed singleton client. An error is returned

--- a/x/launchdarkly/flags/flags_test.go
+++ b/x/launchdarkly/flags/flags_test.go
@@ -11,7 +11,7 @@ func TestSingletonInitialisation(t *testing.T) {
 	t.Run("does not error if SDK key supplied as env var", func(t *testing.T) {
 		os.Setenv(configurationEnvVar, validConfigJSON)
 		defer os.Unsetenv(configurationEnvVar)
-		err := Configure()
+		err := Configure(WithTestMode(nil))
 		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
We're noticing this is an issue when multiple thread or go-routines accessing the LD client at the same time. 

`runtime error: invalid memory address or nil pointer dereference`

The issue is introduced by LD client (initialising in progress) not ready for serving requests. 

A few improvements are listed below: 
- [x] Remove Connect, which means only ready-to-serve client is exposed
- [x] Options to disable big segments

### Context
ticket: https://cultureamp.atlassian.net/browse/COSE-476