### PR TITLE
[COSE-398] feat: enable survey context evaluation for certain accounts

### DIFF
--- a/x/launchdarkly/flags/doc.go
+++ b/x/launchdarkly/flags/doc.go
@@ -70,7 +70,7 @@
 // You can also supply your own evaluation context:
 //   user := flags.NewUser(
 //             "user-id",
-//             flags.WithAccountID("account-id"),
+//             flags.WithUserAccountID("account-id"),
 //   )
 //
 //   val, err := client.QueryBoolWithEvaluationContext("my-flag", user, false)

--- a/x/launchdarkly/flags/evaluationcontext/survey.go
+++ b/x/launchdarkly/flags/evaluationcontext/survey.go
@@ -6,32 +6,56 @@ import (
 )
 
 const (
-	surveyAttributeSurveyID = "surveyID"
+	surveyAttributeSurveyID  = "surveyID"
+	surveyAttributeAccountID = "accountID"
 )
 
 // Survey is a type of context, representing the identifiers and attributes of
 // a survey to evaluate a flag against.
 type Survey struct {
-	key      string
-	surveyID string
+	key       string
+	surveyID  string
+	accountID string
 
 	ldUser lduser.User
 }
 
+// ToLDUser transforms the context implementation into an LDUser object that can
+// be understood by LaunchDarkly when evaluating a flag.
 func (u Survey) ToLDUser() lduser.User {
 	return u.ldUser
+}
+
+// SurveyOption are functions that can be supplied to configure a new survey with
+// additional attributes.
+type SurveyOption func(*Survey)
+
+// WithSurveyAccountID configures the survey with the given account ID.
+// This is the ID of the currently logged in user's parent account/organization,
+// sometimes known as the "account_aggregate_id".
+func WithSurveyAccountID(id string) SurveyOption {
+	return func(u *Survey) {
+		u.accountID = id
+	}
 }
 
 // NewSurvey returns a new Survey object with the given survey ID, there are no options.
 // surveyID is the ID of the currently authenticated survey, and will generally
 // be a "survey_aggregate_id".
-func NewSurvey(surveyID string) Survey {
+func NewSurvey(surveyID string, opts ...SurveyOption) Survey {
 	u := &Survey{
 		key:      surveyID,
 		surveyID: surveyID,
 	}
 
+	for _, opt := range opts {
+		opt(u)
+	}
+
 	userBuilder := lduser.NewUserBuilder(u.key)
+	userBuilder.Custom(
+		surveyAttributeAccountID,
+		ldvalue.String(u.accountID))
 	userBuilder.Custom(
 		surveyAttributeSurveyID,
 		ldvalue.String(u.surveyID))

--- a/x/launchdarkly/flags/evaluationcontext/survey_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/survey_test.go
@@ -10,20 +10,31 @@ import (
 func TestNewSurvey(t *testing.T) {
 	t.Run("can create a survey", func(t *testing.T) {
 		survey := evaluationcontext.NewSurvey("not-a-uuid")
-		assertSurveyAttributes(t, survey, "not-a-uuid")
+		assertSurveyAttributes(t, survey, "not-a-uuid", "")
 
 		survey = evaluationcontext.NewSurvey(
 			"not-a-uuid",
 		)
-		assertSurveyAttributes(t, survey, "not-a-uuid")
+		assertSurveyAttributes(t, survey, "not-a-uuid", "")
+	})
+
+	t.Run("can create a survey with account ID", func(t *testing.T) {
+		survey := evaluationcontext.NewSurvey("not-a-uuid")
+		assertSurveyAttributes(t, survey, "not-a-uuid", "")
+
+		survey = evaluationcontext.NewSurvey(
+			"not-a-uuid",
+			evaluationcontext.WithSurveyAccountID("not-a-uuid"))
+		assertSurveyAttributes(t, survey, "not-a-uuid", "not-a-uuid")
 	})
 }
 
-func assertSurveyAttributes(t *testing.T, survey evaluationcontext.Survey, surveyID string) {
+func assertSurveyAttributes(t *testing.T, survey evaluationcontext.Survey, surveyID string, accountID string) {
 	t.Helper()
 
 	ldUser := survey.ToLDUser()
 
 	assert.Equal(t, surveyID, ldUser.GetKey())
 	assert.Equal(t, surveyID, ldUser.GetAttribute("surveyID").StringValue())
+	assert.Equal(t, accountID, ldUser.GetAttribute("accountID").StringValue())
 }

--- a/x/launchdarkly/flags/evaluationcontext/user.go
+++ b/x/launchdarkly/flags/evaluationcontext/user.go
@@ -28,6 +28,8 @@ type User struct {
 	ldUser lduser.User
 }
 
+// ToLDUser transforms the context implementation into an LDUser object that can
+// be understood by LaunchDarkly when evaluating a flag.
 func (u User) ToLDUser() lduser.User {
 	return u.ldUser
 }
@@ -36,10 +38,10 @@ func (u User) ToLDUser() lduser.User {
 // additional attributes.
 type UserOption func(*User)
 
-// WithAccountID configures the user with the given account ID.
+// WithUserAccountID configures the user with the given account ID.
 // This is the ID of the currently logged in user's parent account/organization,
 // sometimes known as the "account_aggregate_id".
-func WithAccountID(id string) UserOption {
+func WithUserAccountID(id string) UserOption {
 	return func(u *User) {
 		u.accountID = id
 	}
@@ -133,6 +135,6 @@ func UserFromContext(ctx context.Context) (User, error) {
 
 	return NewUser(
 		authenticatedUser.UserID,
-		WithAccountID(authenticatedUser.CustomerAccountID),
+		WithUserAccountID(authenticatedUser.CustomerAccountID),
 		WithRealUserID(authenticatedUser.RealUserID)), nil
 }

--- a/x/launchdarkly/flags/evaluationcontext/user_test.go
+++ b/x/launchdarkly/flags/evaluationcontext/user_test.go
@@ -49,7 +49,7 @@ func TestNewUser(t *testing.T) {
 
 		user = evaluationcontext.NewUser(
 			"not-a-uuid",
-			evaluationcontext.WithAccountID("not-a-uuid"),
+			evaluationcontext.WithUserAccountID("not-a-uuid"),
 			evaluationcontext.WithRealUserID("not-a-uuid"))
 		assertUserAttributes(t, user, "not-a-uuid", "not-a-uuid", "not-a-uuid")
 	})


### PR DESCRIPTION
Enable survey context evaluation for certain accounts based on an account id