### PR TITLE
[COSE-616] Always use `us-east-1` for STS region.

### DIFF
--- a/x/vault/auth/aws_iam_auth.go
+++ b/x/vault/auth/aws_iam_auth.go
@@ -3,7 +3,6 @@ package auth
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -13,7 +12,8 @@ import (
 )
 
 const (
-	loginPath = "auth/aws/login"
+	defaultStsRegion = "us-east-1"
+	loginPath        = "auth/aws/login"
 )
 
 type AWSIamAuth struct {
@@ -33,14 +33,10 @@ func (auth *AWSIamAuth) Login(ctx context.Context, client *vaultapi.Client) (*va
 	if err != nil {
 		return nil, fmt.Errorf("failed to create AWS session: %w", err)
 	}
-	region, ok := os.LookupEnv("AWS_REGION")
-	if !ok {
-		region = ""
-	}
 	loginData, err := awsutil.GenerateLoginData(
 		stscreds.NewCredentials(awsSession, auth.roleArn),
 		"",
-		region,
+		defaultStsRegion,
 		hclog.Default(),
 	)
 	if err != nil {

--- a/x/vault/doc.go
+++ b/x/vault/doc.go
@@ -21,6 +21,6 @@
 //
 // # If no keys are passed to Encrypt or Decrypt a VaultMissingKeysErr will be thrown
 //
-// The default aws region for generating AWS login data is 'us-east-1' which
-// can be changed by using the env var AWS_REGION
+// The default aws region for generating AWS login data is 'us-east-1'. This is
+// is fixed for all environments.
 package vault


### PR DESCRIPTION
This is because we are using the default STS service in `us-east-1` region