### PR TITLE
chore(decrypter/consumer) fix minor issues

### DIFF
--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -261,7 +261,7 @@ func (g *Group) Run(ctx context.Context, handler Handler) <-chan error {
 
 	for i := 0; i < g.config.Count; i++ {
 		wg.Add(1)
-		consumerID := fmt.Sprintf("%s-%s-%d", strings.ToLower(g.config.GroupID), g.ID, i)
+		consumerID := fmt.Sprintf("%s-%d", g.ID, i)
 
 		// Consumers must be created and run in sequential order so that Kafka can
 		// successfully re-balance the group as each is added. This unfortunately

--- a/x/vault/vault_decrypter.go
+++ b/x/vault/vault_decrypter.go
@@ -6,10 +6,11 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/cultureamp/ca-go/x/log"
-	"github.com/cultureamp/ca-go/x/vault/client"
 	vaultapi "github.com/hashicorp/vault/api"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
+	"github.com/cultureamp/ca-go/x/log"
+	"github.com/cultureamp/ca-go/x/vault/client"
 )
 
 type Client interface {
@@ -104,7 +105,6 @@ func (v *Decrypter) decryptWithVault(keyReference string, batch []interface{}, l
 				}
 				continue
 			}
-			logger.Error().Err(err).Msg("Error calling vault decrypt API")
 			return nil, err
 		} else {
 			break


### PR DESCRIPTION
This PR makes the following changes:

- Removes duplicate group name in consumer ID
- Removes decrypt error log from vault decrypter. This was causing a lot of unnecessary noise for "key not found' errors, which are expected when users have been erased.