### PR TITLE
fix: handle empty Vault response

### DIFF
--- a/x/vault/vault_decrypter.go
+++ b/x/vault/vault_decrypter.go
@@ -3,6 +3,7 @@ package vault
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -62,6 +63,16 @@ func (v *Decrypter) decryptByKey(keyReference string, encryptedData []string, lo
 	secret, err := v.decryptWithVault(keyReference, batch, logger, ctx)
 	if err != nil {
 		return nil, err
+	}
+
+	// There are scenarios in which secret will be nil, even if there is no error.
+	// This can happen on the decryption endpoint for a 404 status code and an empty response body
+	// https://github.com/hashicorp/vault/blob/601ad4823cb5b21ede5bf4fc6cbdf638a02feebd/api/logical.go#L241-L249
+	// We need to handle this case otherwise the nil pointer will be dereferenced.
+	if secret == nil {
+		errMsg := fmt.Sprintf("tried to decrypt keyReference: %s but vault returned an empty body", keyReference)
+		logger.Error().Msg(errMsg)
+		return nil, errors.New(errMsg)
 	}
 
 	batchResults, ok := secret.Data["batch_results"].([]interface{})

--- a/x/vault/vault_decrypter_test.go
+++ b/x/vault/vault_decrypter_test.go
@@ -235,6 +235,15 @@ func TestDecrypt(t *testing.T) {
 			returnErr:   nil,
 			expErr:      base64.CorruptInputError(6),
 		},
+		{
+			name:            "should error when Vault returns an empty response",
+			decryptedSecret: nil,
+			vaultResponse:   nil,
+			keyRefs:         []string{"keyRef1"},
+			shouldRenew:     false,
+			returnErr:       nil,
+			expErr:          fmt.Errorf("tried to decrypt keyReference: keyRef1 but vault returned an empty body"),
+		},
 	}
 
 	encryptedData := []string{"encrypted1"}

--- a/x/vault/vault_decrypter_test.go
+++ b/x/vault/vault_decrypter_test.go
@@ -31,6 +31,7 @@ func TestDecrypt(t *testing.T) {
 	tests := []struct {
 		name            string
 		decryptedSecret []string
+		vaultResponse   *vaultapi.Secret
 		data            map[string]interface{}
 		keyRefs         []string
 		shouldRenew     bool
@@ -38,120 +39,204 @@ func TestDecrypt(t *testing.T) {
 		expErr          error
 	}{
 		{
-			"should not error when secret is returned as usual",
-			[]string{decryptedString},
-			map[string]interface{}{
-				"batch_results": []interface{}{
-					map[string]interface{}{
-						"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+			name:            "should not error when secret is returned as usual",
+			decryptedSecret: []string{decryptedString},
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": []interface{}{
+						map[string]interface{}{
+							"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+						},
 					},
 				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
 			},
-			[]string{"keyRef1"},
-			false,
-			nil,
-			nil,
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      nil,
 		},
 		{
-			"should error when no keys are given",
-			nil,
-			nil,
-			[]string{},
-			false,
-			nil,
-			client.ErrVaultMissingKeys,
-		},
-		{
-			"should error when secret is returns wrong number of results",
-			nil,
-			map[string]interface{}{
-				"batch_results": []interface{}{
-					map[string]interface{}{
-						"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
-					},
-					map[string]interface{}{
-						"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
-					},
-				},
+			name:            "should error when no keys are given",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data:          nil,
+				Warnings:      nil,
+				Auth:          nil,
+				WrapInfo:      nil,
 			},
-			[]string{"keyRef1"},
-			false,
-			nil,
-			fmt.Errorf("incorrect number of decrypted values returned"),
+			data:        nil,
+			keyRefs:     []string{},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      client.ErrVaultMissingKeys,
 		},
 		{
-			"should error when getSecret errors",
-			nil,
-			nil,
-			[]string{"keyRef1"},
-			false,
-			fmt.Errorf("secretError"),
-			fmt.Errorf("secretError"),
-		},
-		{
-			"should renew then continue when getSecret returns permission error",
-			[]string{decryptedString},
-			map[string]interface{}{
-				"batch_results": []interface{}{
-					map[string]interface{}{
-						"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+			name:            "should error when secret is returns wrong number of results",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": []interface{}{
+						map[string]interface{}{
+							"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+						},
+						map[string]interface{}{
+							"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+						},
 					},
 				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
 			},
-			[]string{"keyRef1"},
-			true,
-			fmt.Errorf(client.VaultPermissionError),
-			nil,
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      fmt.Errorf("incorrect number of decrypted values returned"),
 		},
 		{
-			"should error when renewClient returns error",
-			nil,
-			nil,
-			[]string{"keyRef1"},
-			false,
-			fmt.Errorf(client.VaultPermissionError),
-			fmt.Errorf(client.VaultPermissionError),
+			name:            "should error when getSecret errors",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data:          nil,
+				Warnings:      nil,
+				Auth:          nil,
+				WrapInfo:      nil,
+			},
+			data:        nil,
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   fmt.Errorf("secretError"),
+			expErr:      fmt.Errorf("secretError"),
 		},
 		{
-			"should error when batch_results is not []interface{}",
-			nil,
-			map[string]interface{}{
-				"batch_results": map[string]interface{}{
-					"plaintext": decryptedString,
+			name:            "should renew then continue when getSecret returns permission error",
+			decryptedSecret: []string{decryptedString},
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": []interface{}{
+						map[string]interface{}{
+							"plaintext": base64.StdEncoding.EncodeToString([]byte(decryptedString)),
+						},
+					},
 				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
 			},
-			[]string{"keyRef1"},
-			false,
-			nil,
-			fmt.Errorf("batch results casting error"),
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: true,
+			returnErr:   fmt.Errorf(client.VaultPermissionError),
+			expErr:      nil,
 		},
 		{
-			"should error when batch_results entries are not map[string]interface{}",
-			nil,
-			map[string]interface{}{
-				"batch_results": []interface{}{"plaintext"},
+			name:            "should error when renewClient returns error",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data:          nil,
+				Warnings:      nil,
+				Auth:          nil,
+				WrapInfo:      nil,
 			},
-			[]string{"keyRef1"},
-			false,
-			nil,
-			fmt.Errorf("batch result casting error"),
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   fmt.Errorf(client.VaultPermissionError),
+			expErr:      fmt.Errorf(client.VaultPermissionError),
 		},
 		{
-			"should error when not base64 encoded",
-			nil,
-			map[string]interface{}{
-				"batch_results": []interface{}{
-					map[string]interface{}{
+			name:            "should error when batch_results is not []interface{}",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": map[string]interface{}{
 						"plaintext": decryptedString,
 					},
 				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
 			},
-			[]string{"keyRef1"},
-			false,
-			nil,
-			base64.CorruptInputError(6),
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      fmt.Errorf("batch results casting error"),
+		},
+		{
+			name:            "should error when batch_results entries are not map[string]interface{}",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": []interface{}{"plaintext"},
+				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
+			},
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      fmt.Errorf("batch result casting error"),
+		},
+		{
+			name:            "should error when not base64 encoded",
+			decryptedSecret: nil,
+			vaultResponse: &vaultapi.Secret{
+				RequestID:     "",
+				LeaseID:       "",
+				LeaseDuration: 0,
+				Renewable:     false,
+				Data: map[string]interface{}{
+					"batch_results": []interface{}{
+						map[string]interface{}{
+							"plaintext": decryptedString,
+						},
+					},
+				},
+				Warnings: nil,
+				Auth:     nil,
+				WrapInfo: nil,
+			},
+			keyRefs:     []string{"keyRef1"},
+			shouldRenew: false,
+			returnErr:   nil,
+			expErr:      base64.CorruptInputError(6),
 		},
 	}
+
 	encryptedData := []string{"encrypted1"}
 	ctx := context.Background()
 	for _, tt := range tests {
@@ -166,30 +251,21 @@ func TestDecrypt(t *testing.T) {
 				return nil
 			},
 			getSecret: func(batch []interface{}, keyReference string, action string) (*vaultapi.Secret, error) {
-				secretReturn := vaultapi.Secret{
-					RequestID:     "",
-					LeaseID:       "",
-					LeaseDuration: 0,
-					Renewable:     false,
-					Data:          tt.data,
-					Warnings:      nil,
-					Auth:          nil,
-					WrapInfo:      nil,
-				}
 				if renewed {
 					tt.returnErr = nil
 				}
-				return &secretReturn, tt.returnErr
+				return tt.vaultResponse, tt.returnErr
 			},
 		}
 
 		t.Run(tt.name, func(t *testing.T) {
+			assertThat := assert.New(t)
 			v := NewVaultDecrypter(mockClient)
 			decryptedSecret, err := v.Decrypt(tt.keyRefs, encryptedData, ctx)
-			assert.Equal(t, tt.decryptedSecret, decryptedSecret)
-			assert.Equal(t, tt.shouldRenew, renewed)
-			fmt.Printf("tt err: %v, err: %v\n", tt.expErr, err)
-			assert.Equal(t, tt.expErr, err)
+
+			assertThat.Equal(tt.decryptedSecret, decryptedSecret)
+			assertThat.Equal(tt.shouldRenew, renewed)
+			assertThat.Equal(tt.expErr, err)
 		})
 	}
 }


### PR DESCRIPTION
## Background

This is a fix for a panic that occurred in Sentry.

Some investigation revealed that this is probably caused by an edge case we haven't handled where the Vault server responds with a 404 status code and an empty body. In that case a `(nil, nil)` set of return values will be passed up in the library code until it returns in our calling code. Since we're only checking the error, the nil pointer will be dereferenced which causes a panic.

Since this panic happened during a likely leader election in our HA Vault cluster, I think that's _probably_ what happened. But whether or not it is, we'll need to handle this edge case.

## What this PR changes

* Add explicit field names for the test cases in the table-driven tests for `vault_decrypter`. I was getting confused trying to figure out which field was which.
* Add test case to model the scenario where Vault returns an empty body
* Add code to handle this scenario

## Refs

https://github.com/hashicorp/vault/issues/18836
