### PR TITLE
Fix consumer goroutine data race

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test:
 .PHONY: test-ci
 test-ci:
 	mkdir artifacts
-	go test ./... -covermode=atomic -coverprofile=artifacts/count.out
+	go test -race ./... -covermode=atomic -coverprofile=artifacts/count.out
 	go tool cover -func=artifacts/count.out | tee artifacts/coverage.out
 
 # ensures that `go mod tidy` has been run after any dependency changes

--- a/x/kafka/consumer/consumer_integration_test.go
+++ b/x/kafka/consumer/consumer_integration_test.go
@@ -123,7 +123,7 @@ func TestConsumerGroup_Run_integration(t *testing.T) {
 			publishDummyEvents(t, ctx, tc, numPublish)
 
 			stopCh := make(chan bool)
-			numConsumed := new(mutexCounter)
+			numConsumed := new(safeCounter)
 			handler := func(ctx context.Context, msg Message) error {
 				time.Sleep(handlerSleepDuration)
 				assert.NotEmpty(t, msg.Value)

--- a/x/kafka/consumer/consumer_test.go
+++ b/x/kafka/consumer/consumer_test.go
@@ -8,7 +8,6 @@ import (
 	"math/rand"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -96,14 +95,16 @@ func TestConsumer_Run(t *testing.T) {
 		return currMsg, nil
 	}).Times(wantTimes)
 
-	consumer := &Consumer{reader: reader}
+	consumer := NewConsumer(&kafka.Dialer{}, Config{},
+		WithKafkaReader(func() Reader { return reader }),
+	)
 
 	i := 0
 	handler := func(ctx context.Context, msg Message) error {
 		require.Equal(t, currMsg, msg.Message)
 		i++
 		if i == wantTimes {
-			require.NoError(t, consumer.Close())
+			consumer.Stop()
 		}
 		return nil
 	}
@@ -115,7 +116,7 @@ func TestConsumer_Run_withBatching(t *testing.T) {
 	ctx := context.Background()
 	wantTimes := 500
 
-	var fetchInvocations int64 = 0
+	fetchInvocations := new(mutexCounter)
 
 	reader := NewMockReader(gomock.NewController(t))
 	reader.EXPECT().Close().Return(nil).Times(1)
@@ -123,27 +124,27 @@ func TestConsumer_Run_withBatching(t *testing.T) {
 
 	// Mock published messages where the key is 0-5 and the value is a constantly growing number
 	reader.EXPECT().FetchMessage(ctx).DoAndReturn(func(_ context.Context) (kafka.Message, error) {
-		atomic.AddInt64(&fetchInvocations, 1)
+		fetchInvocations.Inc()
 		rand.Seed(time.Now().UnixMilli())
+		i := fetchInvocations.Get()
 		msg := kafka.Message{
 			Topic:     "some-topic",
 			Partition: 1,
-			Key:       []byte(fmt.Sprintf("%d", fetchInvocations%5)),
-			Value:     []byte(fmt.Sprintf("%d", fetchInvocations)),
+			Key:       []byte(fmt.Sprintf("%d", i%5)),
+			Value:     []byte(fmt.Sprintf("%d", i)),
 			Time:      time.Now(),
 		}
 		return msg, nil
 	}).AnyTimes()
 
-	consumer := &Consumer{
-		reader:    reader,
-		batchSize: 50,
-		getOrderingKeyFn: func(message kafka.Message) (string, error) {
+	consumer := NewConsumer(&kafka.Dialer{}, Config{},
+		WithKafkaReader(func() Reader { return reader }),
+		WithMessageBatching(50, func(message kafka.Message) (string, error) {
 			return string(message.Key), nil
-		},
-	}
+		}),
+	)
 
-	var handlerInvocations int64
+	handlerInvocations := new(mutexCounter)
 	msgKeyLatestValue := new(sync.Map)
 
 	// Handler asserts that each new message handled for a specific key has a value
@@ -161,9 +162,9 @@ func TestConsumer_Run_withBatching(t *testing.T) {
 		}
 		msgKeyLatestValue.Store(string(msg.Key), val)
 
-		atomic.AddInt64(&handlerInvocations, 1)
-		if handlerInvocations == int64(wantTimes) {
-			require.NoError(t, consumer.Close())
+		handlerInvocations.Inc()
+		if handlerInvocations.Get() == wantTimes {
+			consumer.Stop()
 		}
 		return nil
 	}
@@ -254,10 +255,10 @@ func TestConsumer_Run_error(t *testing.T) {
 			reader.EXPECT().Close().Return(nil).AnyTimes()
 			reader.EXPECT().ReadMessage(ctx).Return(randMsg(), nil).AnyTimes()
 
-			consumer := &Consumer{
-				id:     wantConsumerID,
-				reader: reader,
-			}
+			consumer := NewConsumer(&kafka.Dialer{}, Config{ID: wantConsumerID},
+				WithKafkaReader(func() Reader { return reader }),
+			)
+
 			if tt.setup != nil {
 				tt.setup(t, consumer)
 			}
@@ -267,15 +268,13 @@ func TestConsumer_Run_error(t *testing.T) {
 				if wantErr != nil || gotAttempts < tt.numRetries {
 					return wantHandlerErr
 				}
-				consumer.Close()
+				consumer.Stop()
 				return nil
 			}
 
 			gotErr := consumer.Run(ctx, handler)
 			if wantErr != nil {
 				assert.EqualError(t, gotErr, wantErr.Error())
-			} else {
-				assert.NoError(t, consumer.Close())
 			}
 			assert.Equal(t, tt.shouldNotify, didNotify)
 		})
@@ -318,7 +317,7 @@ func TestNewGroup(t *testing.T) {
 
 			g := NewGroup(&kafka.Dialer{}, tt.config, wantOpts...)
 			require.NotNil(t, g)
-			assert.Empty(t, g.consumers)
+			assert.Empty(t, g.stopChs)
 			wantConfig := tt.config
 			wantConfig.Count = tt.wantNumConsumers
 			assert.Equal(t, wantConfig, g.config)
@@ -349,26 +348,29 @@ func TestGroup_Run(t *testing.T) {
 		return msg, nil
 	}).AnyTimes()
 
-	group := &Group{
-		config: GroupConfig{Count: wantConsumers},
-		opts: []Option{WithKafkaReader(func() Reader {
-			return reader
-		})},
-	}
+	group := NewGroup(&kafka.Dialer{}, GroupConfig{Count: wantConsumers},
+		WithKafkaReader(func() Reader { return reader }),
+	)
 
+	stopCh := make(chan bool)
 	handler := func(ctx context.Context, msg Message) error {
 		msgTracker.Lock()
 		defer msgTracker.Unlock()
 		require.Contains(t, msgTracker.wantMessages, msg.Message)
 		if len(msgTracker.wantMessages) == wantNumMsgs {
-			require.NoError(t, group.Close())
+			stopCh <- true
 		}
 		return nil
 	}
 
 	errCh := group.Run(ctx, handler)
-	for err := range errCh {
-		require.NoError(t, err)
+	for {
+		select {
+		case <-stopCh:
+			return
+		case err := <-errCh:
+			require.NoError(t, err)
+		}
 	}
 }
 
@@ -387,7 +389,6 @@ func TestGroup_Run_readerError(t *testing.T) {
 			name: "reader read error",
 			setupReader: func(m *MockReader) {
 				m.EXPECT().ReadMessage(gomock.Any()).Return(kafka.Message{}, wantErr).Times(1)
-				m.EXPECT().Close().Return(nil).Times(1)
 			},
 		},
 		{
@@ -395,7 +396,6 @@ func TestGroup_Run_readerError(t *testing.T) {
 			withExplicitCommit: true,
 			setupReader: func(m *MockReader) {
 				m.EXPECT().FetchMessage(gomock.Any()).Return(kafka.Message{}, wantErr).Times(1)
-				m.EXPECT().Close().Return(nil).Times(1)
 			},
 		},
 		{
@@ -404,7 +404,6 @@ func TestGroup_Run_readerError(t *testing.T) {
 			setupReader: func(m *MockReader) {
 				m.EXPECT().FetchMessage(gomock.Any()).Return(wantMsg, nil).Times(1)
 				m.EXPECT().CommitMessages(gomock.Any(), wantMsg).Return(wantErr).Times(1)
-				m.EXPECT().Close().Return(nil).Times(1)
 			},
 		},
 		{
@@ -412,7 +411,6 @@ func TestGroup_Run_readerError(t *testing.T) {
 			closeErr: true,
 			setupReader: func(m *MockReader) {
 				m.EXPECT().ReadMessage(gomock.Any()).Return(kafka.Message{}, wantErr).Times(1)
-				m.EXPECT().Close().Return(wantErr).Times(1)
 			},
 		},
 	}
@@ -439,12 +437,8 @@ func TestGroup_Run_readerError(t *testing.T) {
 			})
 			for err := range errCh {
 				require.True(t, errors.Is(err, wantErr))
-				err = group.Close()
-				if tt.closeErr {
-					require.Contains(t, err.Error(), wantErr.Error())
-					return
-				}
-				require.NoError(t, err)
+				group.Stop()
+				require.Contains(t, err.Error(), wantErr.Error())
 			}
 		})
 	}
@@ -488,4 +482,21 @@ func (b *testBackoff) NextBackOff() time.Duration {
 		return backoff.Stop
 	}
 	return 0
+}
+
+type mutexCounter struct {
+	sync.Mutex
+	count int
+}
+
+func (m *mutexCounter) Inc() {
+	m.Lock()
+	defer m.Unlock()
+	m.count++
+}
+
+func (m *mutexCounter) Get() int {
+	m.Lock()
+	defer m.Unlock()
+	return m.count
 }

--- a/x/kafka/consumer/example/consumer/main.go
+++ b/x/kafka/consumer/example/consumer/main.go
@@ -24,7 +24,7 @@ func main() {
 		Topic:   topic,
 	}
 	c := consumer.NewConsumer(kafka.DefaultDialer, cfg)
-	defer c.Close()
+	defer c.Stop()
 
 	log.Printf("consumer started for topic %s\n", topic)
 	if err := c.Run(context.Background(), handle); err != nil {

--- a/x/kafka/consumer/mock_reader_test.go
+++ b/x/kafka/consumer/mock_reader_test.go
@@ -38,7 +38,7 @@ func (m *MockReader) EXPECT() *MockReaderMockRecorder {
 // Close mocks base method.
 func (m *MockReader) Close() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
+	ret := m.ctrl.Call(m, "Stop")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
@@ -46,7 +46,7 @@ func (m *MockReader) Close() error {
 // Close indicates an expected call of Close.
 func (mr *MockReaderMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockReader)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockReader)(nil).Close))
 }
 
 // CommitMessages mocks base method.

--- a/x/kafka/docker-compose.yaml
+++ b/x/kafka/docker-compose.yaml
@@ -50,4 +50,4 @@ services:
       test: [ "CMD", "curl", "--output", "/dev/null", "--silent", "--head", "--fail", "http://schemaregistry:8081/subjects" ]
       interval: 3s
       timeout: 5s
-      retries: 20
+      retries: 40


### PR DESCRIPTION
## 💬 Description

This PR resolves 2 goroutine data races found in the `consumer` package. 

1. Consumer field `close` is accessed by multiple goroutines when using a `Group`.
2. Unit tests increment a counter from multiple goroutines.

Both of these are of low impact since the the first is only relevant when a Group is being stopped and the second is only only applies to a few unit tests. 

Whats interesting is that an atomic increment is currently being used in the unit tests but this still did not pass the data race check. On the other hand, changing to a mutex based counter did pass the race test.

☘️ Proposed Changes

- Use channels to communicate when a consumer is stopped instead of accessing a shared variable.
- Add type `mutexCounter` to tests which allows a counter to be safely incremented and accessed across multiple goroutines.
- Increase schema registry health check retry count in docker compose.