### PR TITLE
Fix consumer fetched message channel reset on batch finish

### DIFF
--- a/x/kafka/consumer/batching.go
+++ b/x/kafka/consumer/batching.go
@@ -65,7 +65,8 @@ func (b *batchProcessor) startFetching(ctx context.Context) error {
 	var fetchContext context.Context
 	fetchContext, b.fetchCancel = context.WithCancel(ctx)
 
-	for i := 0; i < b.batchSize; i++ {
+	batchSize := b.batchSize - len(b.fetched)
+	for i := 0; i < batchSize; i++ {
 		msg, err := b.reader.FetchMessage(fetchContext)
 		if err != nil {
 			if errors.Is(err, context.Canceled) {
@@ -81,7 +82,6 @@ func (b *batchProcessor) startFetching(ctx context.Context) error {
 		}
 		b.fetched <- msg
 	}
-	close(b.fetched)
 	return nil
 }
 
@@ -106,7 +106,7 @@ func (b *batchProcessor) startProcessing(ctx context.Context, handler Handler) e
 	handleErrg, handleCtx := errgroup.WithContext(ctx)
 
 processLoop:
-	for {
+	for i := 0; i < b.batchSize; i++ {
 		msg, ok := b.nextMessage()
 		if !ok {
 			break
@@ -152,7 +152,10 @@ processLoop:
 }
 
 func (b *batchProcessor) reset() {
-	b.fetched = make(chan kafka.Message, b.batchSize)
 	b.processed = make(chan kafka.Message, b.batchSize)
 	b.stop = make(chan struct{})
+}
+
+func (b *batchProcessor) close() {
+	close(b.fetched)
 }

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -119,6 +119,7 @@ func NewConsumer(dialer *kafka.Dialer, config Config, opts ...Option) *Consumer 
 // the context is canceled, the consumer is closed, or an error occurs.
 func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 	bp := newBatchProcessor(c.reader, c.handlerExecutor, c.getOrderingKeyFn, c.batchSize)
+	defer bp.close()
 
 	for {
 		select {


### PR DESCRIPTION
The consumer batching implementation resets the `fetched` channel after each batch. This channel contains messages fetched from the Kafka topic.

We do not want to be resetting the `fetched` channel after a batch finishes early because there is no guarantee that it has been fully drained if a new message arrives just as the batch is marked as finished. This is a race condition that can essentially result in a message getting skipped.

We instead never want to reset the `fetched` channel and ensure any left over messages from a previous batch are processed in the current batch.