### PR TITLE
Fix consumer batching CPU usage

### DIFF
--- a/x/kafka/consumer/batching.go
+++ b/x/kafka/consumer/batching.go
@@ -100,11 +100,6 @@ func (b *batchProcessor) startFetching(ctx context.Context) error {
 	return nil
 }
 
-func (b *batchProcessor) nextMessage() (kafka.Message, bool) {
-	msg, ok := <-b.fetched
-	return msg, ok
-}
-
 func (b *batchProcessor) stopFetching() {
 	b.fetchCancel()
 	close(b.stop)
@@ -125,6 +120,8 @@ processLoop:
 	coordinateLoop:
 		for {
 			select {
+			case <-ctx.Done():
+				return ctx.Err()
 			case fetched, ok := <-b.fetched:
 				if ok {
 					msg = fetched

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -137,7 +137,7 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 		select {
 		case <-c.stopCh:
 			c.debugLogger.Print("Consumer stopped", c.debugKeyVals...)
-			return c.close()
+			return nil
 		default:
 		}
 
@@ -156,8 +156,9 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 // Stop stops the consumer. It waits for the current message/batch (if any) to
 // finish being handled before closing the reader stream, preventing the consumer
 // from reading any more messages.
-func (c *Consumer) Stop() {
+func (c *Consumer) Stop() error {
 	close(c.stopCh)
+	return c.reader.Close()
 }
 
 func (c *Consumer) process(ctx context.Context, handler Handler) error {

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -158,7 +158,12 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 // from reading any more messages.
 func (c *Consumer) Stop() error {
 	close(c.stopCh)
-	return c.reader.Close()
+	c.debugLogger.Print("Consumer stopped", c.debugKeyVals...)
+	if err := c.reader.Close(); err != nil {
+		return fmt.Errorf("unable to close consumer %s reader: %w", c.id, err)
+	}
+	c.debugLogger.Print("Consumer reader closed", c.debugKeyVals...)
+	return nil
 }
 
 func (c *Consumer) process(ctx context.Context, handler Handler) error {
@@ -198,14 +203,6 @@ func (c *Consumer) process(ctx context.Context, handler Handler) error {
 	}
 	c.debugLogger.Print("Committed message offset", debugKeyVals...)
 
-	return nil
-}
-
-func (c *Consumer) close() error {
-	if err := c.reader.Close(); err != nil {
-		return fmt.Errorf("unable to close consumer %s reader: %w", c.id, err)
-	}
-	c.debugLogger.Print("Consumer reader closed", c.debugKeyVals...)
 	return nil
 }
 

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -334,20 +334,3 @@ func NonStopExponentialBackOff() backoff.BackOff { //nolint:ireturn
 	bo.MaxElapsedTime = 0
 	return bo
 }
-
-type safeCounter struct {
-	sync.RWMutex
-	v int
-}
-
-func (m *safeCounter) inc() {
-	m.Lock()
-	defer m.Unlock()
-	m.v++
-}
-
-func (m *safeCounter) val() int {
-	m.RLock()
-	defer m.RUnlock()
-	return m.v
-}

--- a/x/kafka/consumer/consumer_integration_test.go
+++ b/x/kafka/consumer/consumer_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/cultureamp/ca-go/x/kafka/kafkatest"
+	"github.com/cultureamp/ca-go/x/log"
 )
 
 const (
@@ -96,7 +97,7 @@ func TestConsumerGroup_Run_integration(t *testing.T) {
 			partitions:    100,
 			numMessages:   500,
 			consumerCount: 10,
-			opts:          []Option{WithMessageBatching(20, newGetOrderingKey(t, 20))},
+			opts:          []Option{WithMessageBatching(12, newGetOrderingKey(t, 20))},
 		},
 	}
 
@@ -120,7 +121,7 @@ func TestConsumerGroup_Run_integration(t *testing.T) {
 			c := NewGroup(kafka.DefaultDialer, cfg, tt.opts...)
 
 			numPublish := tt.numMessages
-			publishDummyEvents(t, ctx, tc, numPublish)
+			publishDummyEvents(t, ctx, tc, numPublish, "")
 
 			stopCh := make(chan bool)
 			numConsumed := new(safeCounter)
@@ -180,7 +181,7 @@ func TestConsumer_Run_integration(t *testing.T) {
 	c := NewConsumer(kafka.DefaultDialer, cfg)
 
 	numPublish := 100
-	publishDummyEvents(t, ctx, helper, numPublish)
+	publishDummyEvents(t, ctx, helper, numPublish, "")
 	helper.TopicMessageCount(t, ctx)
 
 	consumerCtx, consumerCancel := context.WithCancel(ctx)
@@ -201,16 +202,90 @@ func TestConsumer_Run_integration(t *testing.T) {
 	}
 }
 
-func publishDummyEvents(t *testing.T, ctx context.Context, helper *kafkatest.TestClient[TestEvent], numPublish int) {
+func TestConsumer_Run_integration_incrementalPublishForEarlyBatchTermination(t *testing.T) {
+	ctx, timeoutCancel := context.WithTimeout(context.Background(), timeout)
+	defer timeoutCancel()
+
+	tc := kafkatest.NewTestClient[TestEvent](t, ctx, kafkatest.TestClientConfig{
+		KafkaBrokerHostPort:    brokerHostPort,
+		SchemaRegistryHostPort: schemaRegistryHostPort,
+		NumTopicPartitions:     1,
+	})
+
+	cfg := GroupConfig{
+		Count:   1,
+		Brokers: []string{brokerHostPort},
+		Topic:   tc.Topic,
+		GroupID: uuid.New().String(),
+		DebugLogger: LoggerFunc(func(msg string, keyvals ...any) {
+			log.NewFromCtx(ctx).Debug().Fields(keyvals).Msg(msg)
+		}),
+	}
+	batchSize := 7
+	c := NewGroup(kafka.DefaultDialer, cfg, WithMessageBatching(batchSize, func(ctx context.Context, message kafka.Message) string {
+		return string(message.Key)
+	}))
+
+	go func() {
+		for i := 0; i < 5; i++ {
+			publishDummyEvents(t, context.Background(), tc, i*3, uuid.New().String())
+		}
+	}()
+
+	wantTotal := 30
+	handled := make(chan kafka.Message, wantTotal)
+
+	handler := func(ctx context.Context, msg Message) error {
+		assert.NotEmpty(t, msg.Value)
+		time.Sleep(time.Millisecond * 50)
+		handled <- msg.Message
+		return nil
+	}
+
+	gotTotal := 0
+	errCh := c.Run(ctx, handler)
+	stopped := false
+
+	for {
+		select {
+		case <-handled:
+			gotTotal++
+			if gotTotal == wantTotal {
+				timeoutCancel()
+				stopped = true
+			}
+		case err, ok := <-errCh:
+			if !ok || errors.Is(err, context.Canceled) && stopped {
+				return
+			}
+			require.NoError(t, err)
+		}
+	}
+}
+
+func publishDummyEvents(t *testing.T, ctx context.Context, tc *kafkatest.TestClient[TestEvent], numPublish int, key string) {
 	rand.Seed(time.Now().UnixNano())
-	var events []TestEvent
+	var msgs []kafka.Message
+
 	for i := 0; i < numPublish; i++ {
-		events = append(events, TestEvent{
+		if key == "" {
+			key = strconv.Itoa(i)
+		}
+
+		e := TestEvent{
 			Int: i,
 			Str: strconv.Itoa(i),
-		})
+		}
+
+		msg := kafka.Message{
+			Value: tc.Registry().Encode(t, ctx, e),
+			Time:  time.Now(),
+			Key:   []byte(key),
+		}
+		msgs = append(msgs, msg)
 	}
-	helper.PublishEvents(t, ctx, events...)
+
+	tc.PublishMessages(t, ctx, msgs...)
 }
 
 func newGetOrderingKey(t *testing.T, mod int) GetOrderingKey {

--- a/x/kafka/consumer/consumer_integration_test.go
+++ b/x/kafka/consumer/consumer_integration_test.go
@@ -268,8 +268,9 @@ func publishDummyEvents(t *testing.T, ctx context.Context, tc *kafkatest.TestCli
 	var msgs []kafka.Message
 
 	for i := 0; i < numPublish; i++ {
+		msgKey := key
 		if key == "" {
-			key = strconv.Itoa(i)
+			msgKey = strconv.Itoa(i)
 		}
 
 		e := TestEvent{
@@ -280,7 +281,7 @@ func publishDummyEvents(t *testing.T, ctx context.Context, tc *kafkatest.TestCli
 		msg := kafka.Message{
 			Value: tc.Registry().Encode(t, ctx, e),
 			Time:  time.Now(),
-			Key:   []byte(key),
+			Key:   []byte(msgKey),
 		}
 		msgs = append(msgs, msg)
 	}

--- a/x/kafka/consumer/consumer_test.go
+++ b/x/kafka/consumer/consumer_test.go
@@ -477,3 +477,20 @@ func (b *testBackoff) NextBackOff() time.Duration {
 	}
 	return 0
 }
+
+type safeCounter struct {
+	sync.RWMutex
+	v int
+}
+
+func (m *safeCounter) inc() {
+	m.Lock()
+	defer m.Unlock()
+	m.v++
+}
+
+func (m *safeCounter) val() int {
+	m.RLock()
+	defer m.RUnlock()
+	return m.v
+}

--- a/x/kafka/consumer/example/consumer/main.go
+++ b/x/kafka/consumer/example/consumer/main.go
@@ -24,7 +24,6 @@ func main() {
 		Topic:   topic,
 	}
 	c := consumer.NewConsumer(kafka.DefaultDialer, cfg)
-	defer c.Stop()
 
 	log.Printf("consumer started for topic %s\n", topic)
 	if err := c.Run(context.Background(), handle); err != nil {

--- a/x/kafka/kafkatest/test_client.go
+++ b/x/kafka/kafkatest/test_client.go
@@ -162,3 +162,8 @@ func (c *TestClient[EventType]) Writer() *kafka.Writer {
 func (c *TestClient[EventType]) Reader() *kafka.Reader {
 	return c.reader
 }
+
+// Registry returns the internal kafka test registry.
+func (c *TestClient[EventType]) Registry() *TestRegistry[EventType] {
+	return c.registry
+}


### PR DESCRIPTION
The consumer batching early stop condition in the processing loop is currently very inefficient. The stop condition is a sub loop that loops indefinitely whilst locking and unlocking a sync mutex until the stop condition is reached.

A CPU profile test of the consumer batching showed that the stop condition loop used  ~96% of the CPU.

<img width="839" alt="image" src="https://user-images.githubusercontent.com/20128714/220223146-68f1b975-adfd-47ef-a518-425c3d715c31.png">

This PR changes the stop condition loop so that it blocks until a new message is available or all current messages have been handled, in which the batch can be stopped early.

This change completely removes the extreme CPU usage.

<img width="675" alt="image" src="https://user-images.githubusercontent.com/20128714/220223018-7cbcfb79-7308-48e3-af9b-5ff441cc6e08.png">
