### PR TITLE
User timer for consumer batching early stop condition

### DIFF
--- a/x/kafka/consumer/batching.go
+++ b/x/kafka/consumer/batching.go
@@ -4,18 +4,29 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/segmentio/kafka-go"
 	"golang.org/x/sync/errgroup"
 )
 
+type batchProcessorConfig struct {
+	consumerID       string
+	batchSize        int
+	fetchDuration    time.Duration
+	debugLogger      DebugLogger
+	getOrderingKeyFn GetOrderingKey
+	handlerExecutor  *handlerExecutor
+	reader           Reader
+}
+
 type batchProcessor struct {
 	consumerID       string
 	batchSize        int
 	handlerExecutor  *handlerExecutor
 	reader           Reader
+	fetchTimeout     time.Duration
 	fetched          chan kafka.Message
 	processed        chan kafka.Message
 	stop             chan struct{}
@@ -25,25 +36,29 @@ type batchProcessor struct {
 	debugKeyVals     []any
 }
 
-func newBatchProcessor(consumerID string, debugLogger DebugLogger, reader Reader, handlerExecutor *handlerExecutor, getOrderingKeyFn GetOrderingKey, batchSize int) *batchProcessor {
+func newBatchProcessor(config batchProcessorConfig) *batchProcessor {
+	if config.fetchDuration == time.Duration(0) {
+		config.fetchDuration = time.Second * 10
+	}
 	return &batchProcessor{
-		consumerID:       consumerID,
-		batchSize:        batchSize,
-		handlerExecutor:  handlerExecutor,
-		reader:           reader,
-		fetched:          make(chan kafka.Message, batchSize),
-		processed:        make(chan kafka.Message, batchSize),
-		stop:             make(chan struct{}),
-		getOrderingKeyFn: getOrderingKeyFn,
-		debugLogger:      debugLogger,
-		debugKeyVals:     []any{"consumerId", consumerID, "batchSize", batchSize},
+		consumerID:       config.consumerID,
+		batchSize:        config.batchSize,
+		handlerExecutor:  config.handlerExecutor,
+		reader:           config.reader,
+		fetchTimeout:     config.fetchDuration,
+		getOrderingKeyFn: config.getOrderingKeyFn,
+		debugLogger:      config.debugLogger,
+		debugKeyVals:     []any{"consumerId", config.consumerID, "batchSize", config.consumerID},
 	}
 }
 
 func (b *batchProcessor) process(ctx context.Context, handler Handler) error {
+	b.processed = make(chan kafka.Message, b.batchSize)
+	b.fetched = make(chan kafka.Message, b.batchSize)
 	b.debugKeyVals = append(b.debugKeyVals, "batchId", uuid.New().String())
-	defer b.reset()
+
 	errg, errgCtx := errgroup.WithContext(ctx)
+
 	errg.Go(func() error {
 		return b.startFetching(errgCtx)
 	})
@@ -56,7 +71,8 @@ func (b *batchProcessor) process(ctx context.Context, handler Handler) error {
 		return err
 	}
 	close(b.processed)
-	b.debugLogger.Print(fmt.Sprintf("Finished fetching and handling for %d messages in batch", len(b.processed)), b.debugKeyVals...)
+
+	b.debugLogger.Print(fmt.Sprintf("Preparing to commit offsets for %d messages in batch", len(b.processed)), b.debugKeyVals...)
 
 	var commits []kafka.Message
 
@@ -67,82 +83,50 @@ func (b *batchProcessor) process(ctx context.Context, handler Handler) error {
 	if err := b.reader.CommitMessages(ctx, commits...); err != nil {
 		return fmt.Errorf("unable to commit messages for batch: %w", err)
 	}
-	b.debugLogger.Print(fmt.Sprintf("Committed %d message offsets for batch", len(commits)), b.debugKeyVals...)
+	b.debugLogger.Print(fmt.Sprintf("Committed offsets for %d messages in batch", len(commits)), b.debugKeyVals...)
 	return nil
 }
 
 func (b *batchProcessor) startFetching(ctx context.Context) error {
-	var fetchContext context.Context
-	fetchContext, b.fetchCancel = context.WithCancel(ctx)
-
 	b.debugLogger.Print("Fetching messages for batch", b.debugKeyVals...)
 	defer b.debugLogger.Print("Finished fetching messages for batch", b.debugKeyVals...)
 
-	batchSize := b.batchSize - len(b.fetched)
-	for i := 0; i < batchSize; i++ {
-		msg, err := b.reader.FetchMessage(fetchContext)
+	fetchCtx, cancel := context.WithTimeout(ctx, b.fetchTimeout)
+	defer cancel()
+
+	defer close(b.fetched)
+
+	for i := 0; i < b.batchSize; i++ {
+		msg, err := b.reader.FetchMessage(fetchCtx)
 		if err != nil {
-			if errors.Is(err, io.EOF) {
+			if errors.Is(err, context.DeadlineExceeded) {
+				b.debugLogger.Print("Fetching stopped early due to context deadline exceeded", b.debugKeyVals...)
 				return nil
-			} else if errors.Is(err, context.Canceled) {
-				select {
-				case <-b.stop:
-					b.debugLogger.Print("Fetch message for batch stopped early", append([]any{"messagesFetched", i}, b.debugKeyVals...)...)
-					return nil
-				default:
-				}
 			}
-			return fmt.Errorf("unable to fetch message: %w", err)
+			return err
 		}
-		b.debugLogger.Print("Fetched message", append([]any{"partition", msg.Partition, "offset", msg.Offset}, b.debugKeyVals...)...)
 		b.fetched <- msg
 	}
+
 	return nil
 }
 
-func (b *batchProcessor) stopFetching() {
-	b.fetchCancel()
-	close(b.stop)
-}
-
 func (b *batchProcessor) startProcessing(ctx context.Context, handler Handler) error {
-	messagesReceived := 0
-	messagesProcessed := 0
-	fetchingDone := false
 	orderedChans := make(map[string]chan kafka.Message)
-	handledMessages := make(chan kafka.Message, b.batchSize)
 	handleErrg, handleCtx := errgroup.WithContext(ctx)
 
 processLoop:
 	for i := 0; i < b.batchSize; i++ {
 		var msg kafka.Message
 
-	coordinateLoop:
-		for {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case fetched, ok := <-b.fetched:
-				if ok {
-					msg = fetched
-					messagesReceived++
-					break coordinateLoop
-				}
-				fetchingDone = true
-			case handled := <-handledMessages:
-				b.processed <- handled
-				messagesProcessed++
-				if len(b.fetched) == 0 && messagesReceived > 0 && messagesReceived == messagesProcessed {
-					// End batch process early if there are no new messages available to
-					// be fetched. This is to avoid unnecessary lag.
-					if !fetchingDone {
-						b.debugLogger.Print("Stopping batch early because all current messages are handled and there are no new messages to fetch", b.debugKeyVals...)
-						b.stopFetching()
-					}
-					close(handledMessages)
-					break processLoop
-				}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case fetched, ok := <-b.fetched:
+			if !ok {
+				break processLoop
 			}
+			msg = fetched
 		}
 
 		key := b.getOrderingKeyFn(ctx, msg)
@@ -152,44 +136,39 @@ processLoop:
 
 		if orderedChan, ok := orderedChans[key]; ok {
 			orderedChan <- msg
-			continue
+		} else {
+			orderdChan := make(chan kafka.Message, b.batchSize)
+			orderdChan <- msg
+			orderedChans[key] = orderdChan
+			handleErrg.Go(func() error {
+				return b.handleMessages(handleCtx, key, orderdChan, handler)
+			})
 		}
-
-		msgCh := make(chan kafka.Message, b.batchSize)
-		msgCh <- msg
-		orderedChans[key] = msgCh
-
-		handleErrg.Go(func() error {
-			b.debugLogger.Print(fmt.Sprintf("Handling messages for ordering key %s", key))
-			defer b.debugLogger.Print(fmt.Sprintf("Finished handling all messages for ordering key %s", key))
-
-			for m := range msgCh {
-				debugKeyVals := append([]any{"partition", m.Partition, "offset", m.Offset, "orderingKey", key}, b.debugKeyVals...)
-				b.debugLogger.Print("Executing message handler", debugKeyVals...)
-				if err := b.handlerExecutor.execute(handleCtx, m, handler); err != nil {
-					b.debugLogger.Print("Message handler execution failed", debugKeyVals...)
-					return err
-				}
-				handledMessages <- m
-				b.debugLogger.Print("Finished message handler execution", debugKeyVals...)
-			}
-			return nil
-		})
 	}
 
 	for _, msgCh := range orderedChans {
 		close(msgCh)
 	}
+
+	b.debugLogger.Print("Waiting for all batch messages to be handled", b.debugKeyVals...)
 	err := handleErrg.Wait()
 	b.debugLogger.Print("Finished handling messages for batch", b.debugKeyVals...)
 	return err
 }
 
-func (b *batchProcessor) reset() {
-	b.processed = make(chan kafka.Message, b.batchSize)
-	b.stop = make(chan struct{})
-}
+func (b *batchProcessor) handleMessages(ctx context.Context, orderingKey string, orderedChan chan kafka.Message, handler Handler) error {
+	b.debugLogger.Print(fmt.Sprintf("Handling messages for ordering key %s", orderingKey))
+	defer b.debugLogger.Print(fmt.Sprintf("Finished handling all messages for ordering key %s", orderingKey))
 
-func (b *batchProcessor) close() {
-	close(b.fetched)
+	for m := range orderedChan {
+		debugKeyVals := append([]any{"partition", m.Partition, "offset", m.Offset, "orderingKey", orderingKey}, b.debugKeyVals...)
+		b.debugLogger.Print("Executing message handler", debugKeyVals...)
+		if err := b.handlerExecutor.execute(ctx, m, handler); err != nil {
+			b.debugLogger.Print("Message handler execution failed", debugKeyVals...)
+			return err
+		}
+		b.processed <- m
+		b.debugLogger.Print("Finished message handler execution", debugKeyVals...)
+	}
+	return nil
 }

--- a/x/kafka/consumer/batching.go
+++ b/x/kafka/consumer/batching.go
@@ -29,9 +29,7 @@ type batchProcessor struct {
 	fetchTimeout     time.Duration
 	fetched          chan kafka.Message
 	processed        chan kafka.Message
-	stop             chan struct{}
 	getOrderingKeyFn GetOrderingKey
-	fetchCancel      func()
 	debugLogger      DebugLogger
 	debugKeyVals     []any
 }

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -53,10 +53,15 @@ type Reader interface {
 
 // Config is a configuration object used to create a new Consumer.
 type Config struct {
-	ID          string
-	Brokers     []string
-	Topic       string
-	MaxBytes    int // Default: 1MB
+	ID      string // Default: UUID
+	Brokers []string
+	Topic   string
+
+	MinBytes      int           // Default: 1MB
+	MaxBytes      int           // Default: 10MB
+	MaxWait       time.Duration // Default: 250ms
+	QueueCapacity int           // Default: 100
+
 	DebugLogger DebugLogger
 	groupID     string
 }
@@ -84,6 +89,18 @@ type Consumer struct {
 func NewConsumer(dialer *kafka.Dialer, config Config, opts ...Option) *Consumer {
 	if config.ID == "" {
 		config.ID = uuid.New().String()
+	}
+	if config.MaxBytes == 0 {
+		config.MaxBytes = 1e6 // 1 MB
+	}
+	if config.MaxBytes == 0 {
+		config.MaxBytes = 10e6 // 10 MB
+	}
+	if config.MaxWait == 0 {
+		config.MaxWait = 250 * time.Second
+	}
+	if config.QueueCapacity == 0 {
+		config.QueueCapacity = 100
 	}
 
 	c := &Consumer{

--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -97,7 +97,7 @@ func NewConsumer(dialer *kafka.Dialer, config Config, opts ...Option) *Consumer 
 		config.MaxBytes = 10e6 // 10 MB
 	}
 	if config.MaxWait == 0 {
-		config.MaxWait = 250 * time.Second
+		config.MaxWait = 250 * time.Millisecond
 	}
 	if config.QueueCapacity == 0 {
 		config.QueueCapacity = 100

--- a/x/kafka/consumer/consumer_integration_test.go
+++ b/x/kafka/consumer/consumer_integration_test.go
@@ -30,6 +30,7 @@ const (
 	brokerHostPort         = "localhost:9093"
 	schemaRegistryHostPort = "localhost:8081"
 	timeout                = 60 * time.Second
+	batchFetchDuration     = 5 * time.Second
 )
 
 type TestEvent struct {
@@ -76,28 +77,28 @@ func TestConsumerGroup_Run_integration(t *testing.T) {
 			partitions:    1,
 			numMessages:   500,
 			consumerCount: 1,
-			opts:          []Option{WithMessageBatching(20, newGetOrderingKey(t, 20))},
+			opts:          []Option{WithMessageBatching(20, batchFetchDuration, newGetOrderingKey(t, 20))},
 		},
 		{
 			name:          "1 consumer (batching), 10 partitions, 100 messages)",
 			partitions:    10,
 			numMessages:   100,
 			consumerCount: 1,
-			opts:          []Option{WithMessageBatching(20, newGetOrderingKey(t, 20))},
+			opts:          []Option{WithMessageBatching(20, batchFetchDuration, newGetOrderingKey(t, 20))},
 		},
 		{
 			name:          "10 consumers (batching), 10 partitions, 500 messages",
 			partitions:    10,
 			numMessages:   500,
 			consumerCount: 10,
-			opts:          []Option{WithMessageBatching(20, newGetOrderingKey(t, 20))},
+			opts:          []Option{WithMessageBatching(20, batchFetchDuration, newGetOrderingKey(t, 20))},
 		},
 		{
 			name:          "10 consumers (batching), 100 partitions, 500 messages",
 			partitions:    100,
 			numMessages:   500,
 			consumerCount: 10,
-			opts:          []Option{WithMessageBatching(12, newGetOrderingKey(t, 20))},
+			opts:          []Option{WithMessageBatching(12, batchFetchDuration, newGetOrderingKey(t, 20))},
 		},
 	}
 
@@ -222,7 +223,7 @@ func TestConsumer_Run_integration_incrementalPublishForEarlyBatchTermination(t *
 		}),
 	}
 	batchSize := 7
-	c := NewGroup(kafka.DefaultDialer, cfg, WithMessageBatching(batchSize, func(ctx context.Context, message kafka.Message) string {
+	c := NewGroup(kafka.DefaultDialer, cfg, WithMessageBatching(batchSize, batchFetchDuration, func(ctx context.Context, message kafka.Message) string {
 		return string(message.Key)
 	}))
 

--- a/x/kafka/consumer/consumer_integration_test.go
+++ b/x/kafka/consumer/consumer_integration_test.go
@@ -30,7 +30,7 @@ const (
 	brokerHostPort         = "localhost:9093"
 	schemaRegistryHostPort = "localhost:8081"
 	timeout                = 60 * time.Second
-	batchFetchDuration     = 5 * time.Second
+	batchFetchDuration     = 2 * time.Second
 )
 
 type TestEvent struct {

--- a/x/kafka/consumer/consumer_test.go
+++ b/x/kafka/consumer/consumer_test.go
@@ -137,7 +137,7 @@ func TestConsumer_Run_withBatching(t *testing.T) {
 
 	consumer := NewConsumer(&kafka.Dialer{}, Config{},
 		WithKafkaReader(func() Reader { return reader }),
-		WithMessageBatching(batchSize, func(ctx context.Context, message kafka.Message) string {
+		WithMessageBatching(batchSize, time.Second*10, func(ctx context.Context, message kafka.Message) string {
 			return string(message.Key)
 		}),
 	)

--- a/x/kafka/consumer/consumer_test.go
+++ b/x/kafka/consumer/consumer_test.go
@@ -137,7 +137,7 @@ func TestConsumer_Run_withBatching(t *testing.T) {
 
 	consumer := NewConsumer(&kafka.Dialer{}, Config{},
 		WithKafkaReader(func() Reader { return reader }),
-		WithMessageBatching(batchSize, time.Second*10, func(ctx context.Context, message kafka.Message) string {
+		WithMessageBatching(batchSize, time.Second, func(ctx context.Context, message kafka.Message) string {
 			return string(message.Key)
 		}),
 	)

--- a/x/kafka/consumer/options.go
+++ b/x/kafka/consumer/options.go
@@ -1,6 +1,8 @@
 package consumer
 
 import (
+	"time"
+
 	"github.com/segmentio/kafka-go"
 )
 
@@ -72,12 +74,13 @@ func WithDataDogTracing() Option {
 	}
 }
 
-func WithMessageBatching(batchSize int, getOrderingKeyFn GetOrderingKey) Option {
+func WithMessageBatching(batchSize int, fetchDuration time.Duration, getOrderingKeyFn GetOrderingKey) Option {
 	return func(consumer *Consumer) {
 		consumer.batchSize = batchSize
 		if getOrderingKeyFn != nil {
 			consumer.getOrderingKeyFn = getOrderingKeyFn
 		}
+		consumer.fetchDuration = fetchDuration
 	}
 }
 


### PR DESCRIPTION
## Description

Currently the consumer batch stop condition is done in a manner that aimed to stop the batch in the shortest time possible. This requires a lot of async coordination between the batch fetcher and processor which has ultimately led to intermittent race conditions causing deadlocks. It is possible to fix this within the current early stop condition, however, it would likely result in more cumbersome code all for minimal gains.

The solution to this problem is to simplify the over-engineered code that currently exists. This is achieved by simply using a timer to stop the batch if the batch is not filled to the specified batch size. This will result in the exact same performance for high volumes and will only slightly impact a scenario were consumed events are received in small increments, which is a non issue in the grand scheme of things.