### PR TITLE
chore(consumer): reduce error reporting high cardinality

### DIFF
--- a/x/kafka/consumer/consumer.go
+++ b/x/kafka/consumer/consumer.go
@@ -168,11 +168,11 @@ func (c *Consumer) Run(ctx context.Context, handler Handler) error {
 
 		if c.batchSize > 0 {
 			if err := bp.process(ctx, handler); err != nil {
-				return fmt.Errorf("consumer %s batch error: %w", c.id, err)
+				return fmt.Errorf("consumer batch error: %w", err)
 			}
 		} else {
 			if err := c.process(ctx, handler); err != nil {
-				return fmt.Errorf("consumer %s error: %w", c.id, err)
+				return fmt.Errorf("consumer error: %w", err)
 			}
 		}
 	}
@@ -185,7 +185,7 @@ func (c *Consumer) Stop() error {
 	close(c.stopCh)
 	c.debugLogger.Print("Consumer stopped", c.debugKeyVals...)
 	if err := c.reader.Close(); err != nil {
-		return fmt.Errorf("unable to close consumer %s reader: %w", c.id, err)
+		return fmt.Errorf("unable to close consumer reader: %w", err)
 	}
 	c.debugLogger.Print("Consumer reader closed", c.debugKeyVals...)
 	return nil
@@ -307,7 +307,7 @@ func (g *Group) Run(ctx context.Context, handler Handler) <-chan error {
 		go func() {
 			defer wg.Done()
 			if err := c.Run(ctx, handler); err != nil {
-				errCh <- fmt.Errorf("consumer %s for group %s failed: %w", c.id, g.ID, err)
+				errCh <- fmt.Errorf("consumer failed: %w", err)
 			}
 		}()
 		g.stopChs = append(g.stopChs, c.stopCh)

--- a/x/kafka/consumer/consumer_test.go
+++ b/x/kafka/consumer/consumer_test.go
@@ -180,7 +180,6 @@ func TestConsumer_Run_error(t *testing.T) {
 	var gotAttempts int
 	var didNotify bool
 
-	wantConsumerID := "123"
 	wantHandlerErr := errors.New("some downstream error")
 
 	tests := []struct {
@@ -193,13 +192,13 @@ func TestConsumer_Run_error(t *testing.T) {
 	}{
 		{
 			name:         "consumer unable to handle message",
-			wantError:    fmt.Errorf("consumer %s error: unable to handle message: %w", wantConsumerID, wantHandlerErr),
+			wantError:    fmt.Errorf("consumer error: unable to handle message: %w", wantHandlerErr),
 			shouldNotify: false,
 			numRetries:   0,
 		},
 		{
 			name:         "handler error after backoff retry and notify",
-			wantError:    fmt.Errorf("consumer %s error: unable to handle message: %w", wantConsumerID, wantHandlerErr),
+			wantError:    fmt.Errorf("consumer error: unable to handle message: %w", wantHandlerErr),
 			shouldNotify: true,
 			numRetries:   3,
 			setup: func(t *testing.T, consumer *Consumer) {
@@ -235,7 +234,7 @@ func TestConsumer_Run_error(t *testing.T) {
 		},
 		{
 			name:             "consumer context done error",
-			wantError:        fmt.Errorf("consumer %s error: unable to handle message: context canceled", wantConsumerID),
+			wantError:        errors.New("consumer error: unable to handle message: context canceled"),
 			contextCancelled: true,
 			shouldNotify:     false,
 			numRetries:       0,
@@ -259,7 +258,7 @@ func TestConsumer_Run_error(t *testing.T) {
 			reader.EXPECT().Close().Return(nil).AnyTimes()
 			reader.EXPECT().ReadMessage(ctx).Return(randMsg(), nil).AnyTimes()
 
-			consumer := NewConsumer(&kafka.Dialer{}, Config{ID: wantConsumerID},
+			consumer := NewConsumer(&kafka.Dialer{}, Config{},
 				WithKafkaReader(func() Reader { return reader }),
 			)
 


### PR DESCRIPTION
Removing consumer IDs from returned errors in order to prevent high cardinality in error reporting. The consumer ID is also a public field so it is available to the caller if they wish to still use it for reporting. 