### PR TITLE
fix: prebuild so that linting is faster

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -35,11 +35,14 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
 
+      - name: Build
+        run: go build ./...
+
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51.2
-          args: "-v --verbose --timeout=5m"
+          args: "-v --timeout=5m"
 
   go-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We're getting tons of timeouts in the linting stage of our CI.

Since building takes the most time in the linter, doing that beforehand seems to prevent linter timeout.

[COSE-520](https://cultureamp.atlassian.net/browse/COSE-520)

[COSE-520]: https://cultureamp.atlassian.net/browse/COSE-520?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ