### PR TITLE
fix: ensure clean up after test run

### DIFF
--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -103,6 +103,7 @@ func TestClientTestMode(t *testing.T) {
 		require.NoError(t, os.WriteFile(flagsFilename, []byte(validFlagsJSON), 0666))
 		defer func() {
 			require.NoError(t, os.Unsetenv(flagsFilename))
+			os.Remove(flagsFilename)
 		}()
 
 		c, err := NewClient()


### PR DESCRIPTION
## Context

This test was not removing a temporary file that is created as part of the test logic. That file was causing the test to fail on subsequent runs.

## Change

Add `os.Remove` to the teardown logic