### PR TITLE
fix ld tests fail when local not setup aws credentials

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           version: v1.52.2
           args: "-v --verbose --timeout=5m"
+          skip-pkg-cache: true
 
   go-test:
     runs-on: ubuntu-latest

--- a/x/launchdarkly/flags/client_test.go
+++ b/x/launchdarkly/flags/client_test.go
@@ -160,6 +160,9 @@ func assertTestJSONFlags(t *testing.T, c *Client) {
 }
 
 func TestClientLambdaMode(t *testing.T) {
+	t.Setenv("AWS_ACCESS_KEY_ID", "fake-access-key")
+	t.Setenv("AWS_SECRET_ACCESS_KEY", "fake-secret-access-key")
+
 	t.Run("configures for Lambda (daemon) mode", func(t *testing.T) {
 		t.Setenv(configurationEnvVar, validConfigJSON)
 


### PR DESCRIPTION
The local LD tests failed because of missing local aws credentials. After this change, we don't have to rely on local aws credentials for when running local tests

Error is here:
![Screenshot 2023-09-19 at 4 41 20 pm](https://github.com/cultureamp/ca-go/assets/9697258/30006265-b5de-4105-b16a-1bf4f4245e28)
