### PR TITLE
Add github action to bump patch version number on PR merges to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,22 @@
+name: Release on merge to main
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+jobs:
+  add-git-patch-tag-main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Create version tag for main
+        uses: anothrNick/github-tag-action@1.67.0
+        env: # https://github.com/anothrNick/github-tag-action
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WITH_V: true
+          DEFAULT_BUMP: patch
+          RELEASE_BRANCHES: main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,10 @@
 name: Release on merge to main
 on:
   pull_request:
-    types:
-      - closed
     branches:
       - main
+    types:
+      - closed
 
 jobs:
   add-git-patch-tag-main:
@@ -16,7 +16,7 @@ jobs:
       - name: Create version tag for main
         uses: anothrNick/github-tag-action@1.67.0
         env: # https://github.com/anothrNick/github-tag-action
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WITH_V: true
           DEFAULT_BUMP: patch
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RELEASE_BRANCHES: main
+          WITH_V: true


### PR DESCRIPTION
Introduce a GitHub action pipeline with [anothrNick/github-tag-action](https://github.com/anothrNick/github-tag-action) to automatically increase the patch version of the module when pull requests are merged into the main branch.