### PR TITLE
updated logger to support authorization subdoc

### DIFF
--- a/log/extensions.go
+++ b/log/extensions.go
@@ -7,17 +7,18 @@ import (
 	"runtime"
 	"runtime/debug"
 	"strconv"
+	"strings"
 )
 
 const (
-	// TraceIDHeader = "X-amzn-Trace-ID".
-	TraceIDHeader = "X-amzn-Trace-ID"
-	// RequestIDHeader = "X-Request-ID".
-	RequestIDHeader = "X-Request-ID"
-	// CorrelationIDHeader = "X-Correlation-ID".
-	CorrelationIDHeader = "X-Correlation-ID"
-	// ErrorUUID = "00000000-0000-0000-0000-000000000000".
-	ErrorUUID = "00000000-0000-0000-0000-000000000000"
+	TraceIDHeader                        = "X-amzn-Trace-ID"
+	RequestIDHeader                      = "X-Request-ID"
+	CorrelationIDHeader                  = "X-Correlation-ID"
+	ErrorUUID                            = "00000000-0000-0000-0000-000000000000"
+	AuthorizationHeader                  = "Authorization"
+	XCAServiceGatewayAuthorizationHeader = "X-CA-SGW-Authorization"
+	UserAgentHeader                      = "User-Agent"
+	XForwardedForHeader                  = "X-Forwarded-For"
 )
 
 // AuthPayload contains the customer account_id, user_id and realuser_id uuids.
@@ -33,8 +34,8 @@ type AuthPayload struct {
 	RealUserID string
 }
 
-// WithRequestTracing added a "tracing" subdocument to the log that
-// include important trace, request and correlation headers.
+// WithRequestTracing adds a "tracing" subdocument to the log that
+// includes important trace, request and correlation fields.
 func (lf *Property) WithRequestTracing(req *http.Request) *Property {
 	if req == nil {
 		return lf
@@ -51,8 +52,8 @@ func (lf *Property) WithRequestTracing(req *http.Request) *Property {
 	)
 }
 
-// WithAuthenticatedUserTracing added a "authentication" subdocument to the log that
-// include important account, user and realuser fields.
+// WithAuthenticatedUserTracing adds a "authentication" subdocument to the log that
+// includes important account, user and realuser fields.
 func (lf *Property) WithAuthenticatedUserTracing(auth *AuthPayload) *Property {
 	if auth == nil {
 		return lf
@@ -65,8 +66,28 @@ func (lf *Property) WithAuthenticatedUserTracing(auth *AuthPayload) *Property {
 	)
 }
 
-// WithSystemTracing added a "system" subdocument to the log that
-// include important host, runtime, cpu and loc fields.
+// WithAuthorizationTracing adds a "authorization" subdocument to the log that
+// includes important authorization headers that are automatically redacted.
+func (lf *Property) WithAuthorizationTracing(req *http.Request) *Property {
+	if req == nil {
+		return lf
+	}
+
+	auth_token := req.Header.Get(AuthorizationHeader)
+	xca_auth_token := req.Header.Get(XCAServiceGatewayAuthorizationHeader)
+	user_agent := req.Header.Get(UserAgentHeader)
+	forward_for := req.Header.Get(XForwardedForHeader)
+
+	return lf.doc("authorization", SubDoc().
+		Str("authorization_token", redactString(auth_token)).
+		Str("xca_service_authorization_token", redactString(xca_auth_token)).
+		Str("user_agent", user_agent).
+		Str("x_forwarded_for", forward_for),
+	)
+}
+
+// WithSystemTracing adds a "system" subdocument to the log that
+// includes important host, runtime, cpu and loc fields.
 func (lf *Property) WithSystemTracing() *Property {
 	host, _ := os.Hostname()
 	_, path, line, ok := runtime.Caller(1)
@@ -84,4 +105,41 @@ func (lf *Property) WithSystemTracing() *Property {
 		Str("go_version", buildInfo.GoVersion).
 		Str("loc", file+":"+strconv.Itoa(line)),
 	)
+}
+
+func redactString(s string) string {
+	const minStars = 10
+	const maxStars = 20
+
+	l := len(s)
+	if l == 0 {
+		return ""
+	}
+
+	var b strings.Builder
+	b.Grow(l + maxStars)
+
+	aQuarter := l / 4
+	stars := minStars
+	if stars < aQuarter {
+		stars = maxStars
+	}
+
+	// write first quater of the chars if greater than minimum number of stars
+	if l > minStars {
+		b.WriteString(s[:aQuarter])
+	}
+
+	// no matter how long the string, show at least 10 "*" in the middle
+	for i := 0; i < stars; i++ {
+		b.WriteString("*")
+	}
+
+	// write remaining 1 or 2 chars
+	if l > minStars {
+		i := l - aQuarter
+		b.WriteString(s[i:])
+	}
+
+	return b.String()
 }

--- a/log/extensions.go
+++ b/log/extensions.go
@@ -52,7 +52,7 @@ func (lf *Property) WithRequestTracing(req *http.Request) *Property {
 	)
 }
 
-// WithAuthenticatedUserTracing adds a "authentication" subdocument to the log that
+// WithAuthenticatedUserTracing adds an "authentication" subdocument to the log that
 // includes important account, user and realuser fields.
 func (lf *Property) WithAuthenticatedUserTracing(auth *AuthPayload) *Property {
 	if auth == nil {
@@ -66,7 +66,7 @@ func (lf *Property) WithAuthenticatedUserTracing(auth *AuthPayload) *Property {
 	)
 }
 
-// WithAuthorizationTracing adds a "authorization" subdocument to the log that
+// WithAuthorizationTracing adds an "authorization" subdocument to the log that
 // includes important authorization headers that are automatically redacted.
 func (lf *Property) WithAuthorizationTracing(req *http.Request) *Property {
 	if req == nil {

--- a/log/extensions_test.go
+++ b/log/extensions_test.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtensionWithRequestTracing(t *testing.T) {
@@ -41,10 +43,10 @@ func TestExtensionWithRequestTracing(t *testing.T) {
 			Int("test-number", 1),
 		).Details("logging should contain request tracing")
 
-	// Output:
-	// "severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_nil_request_tracing","properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should not contain request tracing"}
-	// {"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_missing_headers_request_tracing","tracing":{"trace_id":"","request_id":"","correlation_id":""},"properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should not contain request tracing"}
-	// {"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_request_tracing","tracing":{"trace_id":"trace_123_id","request_id":"request_456_id","correlation_id":"correlation_789_id"},"properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should contain request tracing"}
+	// Local Console Output:
+	// 2024-02-14T12:38:29+11:00 INF event="logging should not contain request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2024-02-14T12:38:29+11:00 INF event="logging should log empty request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_missing_headers_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1} tracing={"correlation_id":"","request_id":"","trace_id":""}
+	// 2024-02-14T12:38:29+11:00 INF event="logging should contain request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1} tracing={"correlation_id":"correlation_789_id","request_id":"request_456_id","trace_id":"trace_123_id"}
 }
 
 func TestExtensionWithAuthenticationUserTracing(t *testing.T) {
@@ -53,22 +55,22 @@ func TestExtensionWithAuthenticationUserTracing(t *testing.T) {
 	logger := NewLogger(config)
 
 	// First test nil Auth Payload
-	logger.Info("info_with_nil_auth_tracing").
+	logger.Info("info_with_nil_authN_tracing").
 		WithAuthenticatedUserTracing(nil).
 		Properties(SubDoc().
 			Str("resource", "resource_id").
 			Int("test-number", 1),
-		).Details("logging should not contain auth tracing")
+		).Details("logging should not contain authN tracing")
 
 	// Next with empty Auth Payload
 	auth := &AuthPayload{}
 
-	logger.Info("info_with_missing_auth_tracing").
+	logger.Info("info_with_missing_authN_tracing").
 		WithAuthenticatedUserTracing(auth).
 		Properties(SubDoc().
 			Str("resource", "resource_id").
 			Int("test-number", 1),
-		).Details("logging should log empty auth tracing")
+		).Details("logging should log empty authN tracing")
 
 	// Finally with Auth Payload set
 	auth = &AuthPayload{
@@ -77,17 +79,59 @@ func TestExtensionWithAuthenticationUserTracing(t *testing.T) {
 		UserID:            "user_789_id",
 	}
 
-	logger.Info("info_with_auth_tracing").
+	logger.Info("info_with_authN_tracing").
 		WithAuthenticatedUserTracing(auth).
 		Properties(SubDoc().
 			Str("resource", "resource_id").
 			Int("test-number", 1),
-		).Details("logging should contain auth tracing")
+		).Details("logging should contain authN tracing")
 
-	// Output:
-	//{"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_nil_auth_tracing","properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should not contain auth tracing"}
-	// {"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_missing_auth_tracing","authentication":{"account_id":"","realuser_id":"","user_id":""},"properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should not contain auth tracing"}
-	// {"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_auth_tracing","authentication":{"account_id":"account_123_id","realuser_id":"real_456_id","user_id":"user_789_id"},"properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should contain auth tracing"}
+	// Local Console Output:
+	// 2024-02-14T12:41:18+11:00 INF event="logging should not contain authN tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2024-02-14T12:41:18+11:00 INF event="logging should log empty authN tracing" app= app_version=1.0.0 authentication={"account_id":"","realuser_id":"","user_id":""} aws_account_id=development aws_region= event=info_with_missing_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2024-02-14T12:41:18+11:00 INF event="logging should contain authN tracing" app= app_version=1.0.0 authentication={"account_id":"account_123_id","realuser_id":"real_456_id","user_id":"user_789_id"} aws_account_id=development aws_region= event=info_with_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+}
+
+func TestExtensionWithAuthorizationTracing(t *testing.T) {
+	config := NewLoggerConfig()
+	config.Quiet = false
+	logger := NewLogger(config)
+
+	// First test nil Request
+	logger.Info("info_with_nil_authZ_tracing").
+		WithAuthorizationTracing(nil).
+		Properties(SubDoc().
+			Str("resource", "resource_id").
+			Int("test-number", 1),
+		).Details("logging should not contain authZ tracing")
+
+	// Next with Request but no headers
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/foo", nil)
+
+	logger.Info("info_with_missing_headers_authZ_tracing").
+		WithAuthorizationTracing(req).
+		Properties(SubDoc().
+			Str("resource", "resource_id").
+			Int("test-number", 1),
+		).Details("logging should log empty authZ tracing")
+
+	// Finally with headers set
+	req.Header.Add(AuthorizationHeader, "AWS 123 token")
+	req.Header.Add(XCAServiceGatewayAuthorizationHeader, "Bearer 456 token")
+	req.Header.Add(XForwardedForHeader, "123.123.123")
+	req.Header.Add(UserAgentHeader, "node")
+
+	logger.Info("info_with_authZ_tracing").
+		WithAuthorizationTracing(req).
+		Properties(SubDoc().
+			Str("resource", "resource_id").
+			Int("test-number", 1),
+		).Details("logging should contain authZ tracing")
+
+	// Local Console Output:
+	// 2024-02-14T12:42:29+11:00 INF event="logging should not contain authZ tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2024-02-14T12:42:29+11:00 INF event="logging should log empty authZ tracing" app= app_version=1.0.0 authorization={"authorization_token":"","user_agent":"","x_forwarded_for":"","xca_service_authorization_token":""} aws_account_id=development aws_region= event=info_with_missing_headers_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2024-02-14T12:42:29+11:00 INF event="logging should contain authZ tracing" app= app_version=1.0.0 authorization={"authorization_token":"AWS**********ken","user_agent":"node","x_forwarded_for":"123.123.123","xca_service_authorization_token":"Bear**********oken"} aws_account_id=development aws_region= event=info_with_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
 }
 
 func TestExtensionWithSystemTracing(t *testing.T) {
@@ -102,6 +146,61 @@ func TestExtensionWithSystemTracing(t *testing.T) {
 			Int("test-number", 1),
 		).Details("logging should contain system tracing")
 
-	// Output:
-	// {"severity":"info","app":"","app_version":"1.0.0","aws_region":"","aws_account_id":"local","farm":"local","product":"","event":"info_with_nil_auth_tracing","system":{"os":"darwin","num_cpu":8,"host":"mridgway-6RR4DK","loc":"/opt/homebrew/opt/go/libexec/src/runtime/asm_arm64.s:1197"},"properties":{"resource":"resource_id","test-number":1},"time":"2024-01-17T15:38:13+11:00","details":"logging should contain system tracing"}
+	// Local Console Output:
+	// 2024-02-14T12:42:29+11:00 INF event="logging should contain system tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_auth_tracing farm=local product= properties={"resource":"resource_id","test-number":1} system={"go_version":"go1.21.7","host":"mridgway-6RR4DK","loc":"extensions_test.go:143","num_cpu":8,"os":"darwin","pid":3721}
+}
+
+func TestStringRedaction(t *testing.T) {
+	testCases := []struct {
+		desc     string
+		str      string
+		redacted string
+	}{
+		{
+			desc:     "Empty string returns empty string",
+			str:      "",
+			redacted: "",
+		},
+		{
+			desc:     "String less than 10 chars shows 10 stars",
+			str:      "1234",
+			redacted: "**********",
+		},
+		{
+			desc:     "String equals 10 chars shows 10 stars",
+			str:      "1234567890",
+			redacted: "**********",
+		},
+		{
+			desc:     "String equals 11 chars shows first char and last chars and 10 stars",
+			str:      "12345678901",
+			redacted: "12**********01",
+		},
+		{
+			desc:     "String equals 12 chars shows first and last chars with 10 stars in the middle",
+			str:      "123456789012",
+			redacted: "123**********012",
+		},
+		{
+			desc:     "String equals 20 chars shows first and last chars with 10 stars in the middle",
+			str:      "12345678901234567890",
+			redacted: "12345**********67890",
+		},
+		{
+			desc:     "String equals 30 chars shows first and last chars with 10 stars in the middle",
+			str:      "123456789012345678901234567890",
+			redacted: "1234567**********4567890",
+		},
+		{
+			desc:     "Real world test",
+			str:      "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiJkNDc1ZGQ1Yi1mMTZjLTRiZmItODk4Yy1kMzQzNWEyMTUyMzkiLCJlZmZlY3RpdmVVc2VySWQiOiI1YjMxNjY0YS03NjEwLTRmYjAtYmM4OS1mOWY4ZTIwYmY4Y2UiLCJyZWFsVXNlcklkIjoiNWIzMTY2NGEtNzYxMC00ZmIwLWJjODktZjlmOGUrUC021FhB_zuETHmhQUXOfIyTkpvhcJfrrqwdcc-KmJGznckACLj65VmnayoltCce_3JGJ361GuutgrDaqp1aW4D05mvO8CCIRwGq8hTcRoi7IdXYSnA6UlXtLNYvttz92jaAAoNDCZmbbP-umHac4x5AT1xY-kVyh7VAadZG_Qe7dZWU9WCHtCV3mqTMwX9B9zrqY2NrpblevbbYpoiJiXOU7kex4BEivF1K6VWI-mpcmKtEOZLx2E",
+			redacted: "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiJkNDc1ZGQ1Yi1mMTZjLTRiZmItODk4Yy1kMzQzNWEyMTUyMzkiLCJlZmZlY3R********************vttz92jaAAoNDCZmbbP-umHac4x5AT1xY-kVyh7VAadZG_Qe7dZWU9WCHtCV3mqTMwX9B9zrqY2NrpblevbbYpoiJiXOU7kex4BEivF1K6VWI-mpcmKtEOZLx2E",
+		},
+	}
+	for _, tC := range testCases {
+		t.Run(tC.desc, func(t *testing.T) {
+			r := redactString(tC.str)
+			assert.Equal(t, tC.redacted, r, tC.desc)
+		})
+	}
 }


### PR DESCRIPTION
Based on the problems perform-core have had with authorization headers when calling the task-service, we've updated the logging std to include Authorization and XCA headers to the standard logs. 

See: https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3114598406/Logging+Standard#Authorization-fields

This PR adds that support to the logger but adding an extension `WithAuthorizationTracing(req *http.Request)` which adds the "authorization" subdoc and the authz request headers as properties.