### PR TITLE
Kms client rework

### DIFF
--- a/cipher/clients.go
+++ b/cipher/clients.go
@@ -15,13 +15,13 @@ type KMSClient interface {
 }
 
 type awsKMSClient struct {
-	kmsClient *kms.Client
+	aws *kms.Client
 }
 
 func newAWSKMSClient(region string) *awsKMSClient {
 	client := kms.New(kms.Options{Region: region})
 	return &awsKMSClient{
-		kmsClient: client,
+		aws: client,
 	}
 }
 
@@ -31,7 +31,7 @@ func (c *awsKMSClient) Encrypt(ctx context.Context, keyId string, plainStr strin
 		Plaintext: []byte(plainStr),
 	}
 
-	result, err := c.kmsClient.Encrypt(ctx, input)
+	result, err := c.aws.Encrypt(ctx, input)
 	if err != nil {
 		return "", err
 	}
@@ -51,27 +51,11 @@ func (c *awsKMSClient) Decrypt(ctx context.Context, keyId string, encryptedStr s
 		CiphertextBlob: blob,
 	}
 
-	result, err := c.kmsClient.Decrypt(ctx, input)
+	result, err := c.aws.Decrypt(ctx, input)
 	if err != nil {
 		return "", err
 	}
 
 	decStr := string(result.Plaintext)
 	return decStr, nil
-}
-
-type testRunnerClient struct{}
-
-func newTestRunnerClient() *testRunnerClient {
-	return &testRunnerClient{}
-}
-
-// Encrypt on the test runner just returns the "plainStr" as the encrypted encryptedStr.
-func (c *testRunnerClient) Encrypt(ctx context.Context, _ string, plainStr string) (string, error) {
-	return plainStr, nil
-}
-
-// Decrypt on the test runner just returns the "encryptedStr" as the decrypted plainstr.
-func (c *testRunnerClient) Decrypt(ctx context.Context, _ string, encryptedStr string) (string, error) {
-	return encryptedStr, nil
 }

--- a/cipher/kms.go
+++ b/cipher/kms.go
@@ -6,7 +6,7 @@ import (
 
 // KMSCipher supports basic Encrypt & Decrypt methods.
 type KMSCipher struct {
-	client KMSClient
+	Client KMSClient
 }
 
 // NewKMSCipher creates a new kms cipher for the specific "region" and "keyid".
@@ -22,10 +22,10 @@ func NewKMSCipherWithClient(client KMSClient) *KMSCipher {
 
 // Encrypt will encrypt the "plainStr" using the region and keyID of the cipher.
 func (c *KMSCipher) Encrypt(ctx context.Context, keyID string, plainStr string) (string, error) {
-	return c.client.Encrypt(ctx, keyID, plainStr)
+	return c.Client.Encrypt(ctx, keyID, plainStr)
 }
 
 // Decrypt will decrypt the "encryptedStr" using the region and keyID of the cipher.
 func (c *KMSCipher) Decrypt(ctx context.Context, keyID string, encryptedStr string) (string, error) {
-	return c.client.Decrypt(ctx, keyID, encryptedStr)
+	return c.Client.Decrypt(ctx, keyID, encryptedStr)
 }

--- a/cipher/kms_example_test.go
+++ b/cipher/kms_example_test.go
@@ -7,10 +7,11 @@ import (
 	"github.com/cultureamp/ca-go/cipher"
 )
 
-func BasicExamples() {
-	// os.SetEnv("AWS_REGION", "us-west-2")
+func Example() {
+	// Note: Make sure AWS_REGION is set in the environment
 
 	ctx := context.Background()
+
 	// Replace the following example key ARN with any valid key identfier
 	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 

--- a/cipher/kms_test.go
+++ b/cipher/kms_test.go
@@ -42,7 +42,7 @@ func TestEncrypt(t *testing.T) {
 		// arrange
 		mockKmsClient := &mockKMSClient{}
 		crypto := NewKMSCipherWithClient(mockKmsClient)
-		crypto.client = mockKmsClient
+		crypto.Client = mockKmsClient
 
 		mockKmsClient.On("Encrypt", ctx, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 
@@ -83,7 +83,7 @@ func TestDecrypt(t *testing.T) {
 		// arrange
 		mockKmsClient := &mockKMSClient{}
 		crypto := NewKMSCipherWithClient(mockKmsClient)
-		crypto.client = mockKmsClient
+		crypto.Client = mockKmsClient
 
 		mockKmsClient.On("Decrypt", ctx, mock.Anything, mock.Anything).Return(nil, errors.New("error"))
 

--- a/cipher/package.go
+++ b/cipher/package.go
@@ -2,9 +2,7 @@ package cipher
 
 import (
 	"context"
-	"flag"
 	"os"
-	"strings"
 )
 
 var DefaultKMSCipher *KMSCipher = getInstance()
@@ -12,12 +10,8 @@ var DefaultKMSCipher *KMSCipher = getInstance()
 func getInstance() *KMSCipher {
 	var client KMSClient
 
-	if isTestMode() {
-		client = newTestRunnerClient()
-	} else {
-		region := os.Getenv("AWS_REGION")
-		client = newAWSKMSClient(region)
-	}
+	region := os.Getenv("AWS_REGION")
+	client = newAWSKMSClient(region)
 	return NewKMSCipherWithClient(client)
 }
 
@@ -29,17 +23,4 @@ func Encrypt(ctx context.Context, keyId string, plainStr string) (string, error)
 // Decrypt uses the default AWS_REGION and KMS_KEY_ID to kms decrypt "encryptedStr".
 func Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error) {
 	return DefaultKMSCipher.Decrypt(ctx, keyId, encryptedStr)
-}
-
-func isTestMode() bool {
-	// https://stackoverflow.com/questions/14249217/how-do-i-know-im-running-within-go-test
-	argZero := os.Args[0]
-
-	if strings.HasSuffix(argZero, ".test") ||
-		strings.Contains(argZero, "/_test/") ||
-		flag.Lookup("test.v") != nil {
-		return true
-	}
-
-	return false
 }

--- a/cipher/package_test.go
+++ b/cipher/package_test.go
@@ -14,7 +14,7 @@ func TestPackageEncrypt(t *testing.T) {
 
 	// replace the package level client with our mock
 	stdClient := cipher.DefaultKMSCipher.Client
-	cipher.DefaultKMSCipher.Client = newTestRunnerClient()
+	cipher.DefaultKMSCipher.Client = newMockedCipherClient()
 	defer func() {
 		cipher.DefaultKMSCipher.Client = stdClient
 	}()
@@ -27,18 +27,18 @@ func TestPackageEncrypt(t *testing.T) {
 	assert.Equal(t, "test_plain_str", plainText)
 }
 
-type testRunnerClient struct{}
+type mockedCipherClient struct{}
 
-func newTestRunnerClient() *testRunnerClient {
-	return &testRunnerClient{}
+func newMockedCipherClient() *mockedCipherClient {
+	return &mockedCipherClient{}
 }
 
 // Encrypt on the test runner just returns the "plainStr" as the encrypted encryptedStr.
-func (c *testRunnerClient) Encrypt(ctx context.Context, _ string, plainStr string) (string, error) {
+func (c *mockedCipherClient) Encrypt(ctx context.Context, _ string, plainStr string) (string, error) {
 	return plainStr, nil
 }
 
 // Decrypt on the test runner just returns the "encryptedStr" as the decrypted plainstr.
-func (c *testRunnerClient) Decrypt(ctx context.Context, _ string, encryptedStr string) (string, error) {
+func (c *mockedCipherClient) Decrypt(ctx context.Context, _ string, encryptedStr string) (string, error) {
 	return encryptedStr, nil
 }

--- a/cipher/package_test.go
+++ b/cipher/package_test.go
@@ -12,10 +12,33 @@ func TestPackageEncrypt(t *testing.T) {
 	ctx := context.Background()
 	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 
+	// replace the package level client with our mock
+	stdClient := cipher.DefaultKMSCipher.Client
+	cipher.DefaultKMSCipher.Client = newTestRunnerClient()
+	defer func() {
+		cipher.DefaultKMSCipher.Client = stdClient
+	}()
+
 	cipherText, err := cipher.Encrypt(ctx, keyId, "test_plain_str")
 	assert.Nil(t, err)
 
 	plainText, err := cipher.Decrypt(ctx, keyId, cipherText)
 	assert.Nil(t, err)
 	assert.Equal(t, "test_plain_str", plainText)
+}
+
+type testRunnerClient struct{}
+
+func newTestRunnerClient() *testRunnerClient {
+	return &testRunnerClient{}
+}
+
+// Encrypt on the test runner just returns the "plainStr" as the encrypted encryptedStr.
+func (c *testRunnerClient) Encrypt(ctx context.Context, _ string, plainStr string) (string, error) {
+	return plainStr, nil
+}
+
+// Decrypt on the test runner just returns the "encryptedStr" as the decrypted plainstr.
+func (c *testRunnerClient) Decrypt(ctx context.Context, _ string, encryptedStr string) (string, error) {
+	return encryptedStr, nil
 }


### PR DESCRIPTION
Removed the automatic magic that detects if running inside a test and swaps out the implementation for a testRunnerClient.

Updated the CIPHER.md and examples.