### PR TITLE
improved cipher test coverage

### DIFF
--- a/cipher/client.go
+++ b/cipher/client.go
@@ -8,18 +8,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-// KMSClient used for mock testing.
-type KMSClient interface {
-	Encrypt(ctx context.Context, keyId string, plainStr string) (string, error)
-	Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error)
-}
-
 type awsKMSClient struct {
 	aws *kms.Client
 }
 
-func newAWSKMSClient(region string) *awsKMSClient {
-	client := kms.New(kms.Options{Region: region})
+func newAWSKMSClient(region string, optFns ...func(*kms.Options)) *awsKMSClient {
+	client := kms.New(kms.Options{Region: region}, optFns...)
 	return &awsKMSClient{
 		aws: client,
 	}

--- a/cipher/client_test.go
+++ b/cipher/client_test.go
@@ -1,0 +1,127 @@
+package cipher
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kms"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestClientEncrypt(t *testing.T) {
+	ctx := context.Background()
+	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	region := "region"
+
+	t.Run("Success: With Mocked HTTP Client", func(t *testing.T) {
+		bodyReader := io.NopCloser(strings.NewReader(`{
+			"CiphertextBlob": "SGVsbG8sIHBsYXlncm91bmQ=",
+			"EncryptionAlgorithm": "SYMMETRIC_DEFAULT",
+			"KeyId": "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+		}`))
+
+		expectedResp := &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       bodyReader,
+		}
+		mockHTTPClient := mockKMSClient{}
+		mockHTTPClient.On("Do", mock.Anything).Return(expectedResp, nil)
+
+		client := newAWSKMSClient(region, func(opt *kms.Options) { opt.HTTPClient = &mockHTTPClient })
+
+		cipherText, err := client.Encrypt(ctx, keyId, "Hello, playground")
+		assert.Nil(t, err)
+		assert.Equal(t, "SGVsbG8sIHBsYXlncm91bmQ=", cipherText)
+	})
+
+	t.Run("Error: Mocked HTTP Client returns error", func(t *testing.T) {
+		mockHTTPClient := mockKMSClient{}
+		mockHTTPClient.On("Do", mock.Anything).Return(nil, fmt.Errorf("expected error"))
+
+		client := newAWSKMSClient(region, func(opt *kms.Options) {
+			opt.HTTPClient = &mockHTTPClient
+			opt.Retryer = &aws.NopRetryer{}
+		})
+
+		cipherText, err := client.Encrypt(ctx, keyId, "Hello, playground")
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "expected error")
+		assert.Equal(t, "", cipherText)
+	})
+}
+
+func TestClientDecrypt(t *testing.T) {
+	ctx := context.Background()
+	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
+	region := "region"
+
+	t.Run("Success: With Mocked HTTP Client", func(t *testing.T) {
+		bodyReader := io.NopCloser(strings.NewReader(`{
+			"CiphertextForRecipient": "SGVsbG8sIHBsYXlncm91bmQ=",
+			"EncryptionAlgorithm": "SYMMETRIC_DEFAULT",
+			"KeyId": "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab",
+			"Plaintext": "SGVsbG8sIHBsYXlncm91bmQ="
+		}`))
+
+		expectedResp := &http.Response{
+			StatusCode: 200,
+			Header:     http.Header{},
+			Body:       bodyReader,
+		}
+		mockHTTPClient := mockKMSClient{}
+		mockHTTPClient.On("Do", mock.Anything).Return(expectedResp, nil)
+
+		client := newAWSKMSClient(region, func(opt *kms.Options) { opt.HTTPClient = &mockHTTPClient })
+
+		plainText, err := client.Decrypt(ctx, keyId, "SGVsbG8sIHBsYXlncm91bmQ=")
+		assert.Nil(t, err)
+		assert.Equal(t, "Hello, playground", plainText)
+	})
+
+	t.Run("Error: Mocked HTTP Client returns error", func(t *testing.T) {
+		mockHTTPClient := mockKMSClient{}
+		mockHTTPClient.On("Do", mock.Anything).Return(nil, fmt.Errorf("expected error"))
+
+		client := newAWSKMSClient(region, func(opt *kms.Options) {
+			opt.HTTPClient = &mockHTTPClient
+			opt.Retryer = &aws.NopRetryer{}
+		})
+
+		plainText, err := client.Decrypt(ctx, keyId, "SGVsbG8sIHBsYXlncm91bmQ=")
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "expected error")
+		assert.Equal(t, "", plainText)
+	})
+
+	t.Run("Error: Bad Base64 CipherText", func(t *testing.T) {
+		mockHTTPClient := mockKMSClient{}
+		mockHTTPClient.On("Do", mock.Anything).Return(nil, nil)
+
+		client := newAWSKMSClient(region, func(opt *kms.Options) {
+			opt.HTTPClient = &mockHTTPClient
+			opt.Retryer = &aws.NopRetryer{}
+		})
+
+		plainText, err := client.Decrypt(ctx, keyId, "%^&*()")
+		assert.NotNil(t, err)
+		assert.ErrorContains(t, err, "illegal base64 data")
+		assert.Equal(t, "", plainText)
+	})
+}
+
+type mockHTTPClient struct {
+	mock.Mock
+}
+
+func (_m *mockKMSClient) Do(req *http.Request) (*http.Response, error) {
+	args := _m.Called(req)
+	output, _ := args.Get(0).(*http.Response)
+	return output, args.Error(1)
+}

--- a/cipher/kms.go
+++ b/cipher/kms.go
@@ -4,28 +4,34 @@ import (
 	"context"
 )
 
-// KMSCipher supports basic Encrypt & Decrypt methods.
-type KMSCipher struct {
-	Client KMSClient
+// KMSCipher used for mock testing.
+type KMSCipher interface {
+	Encrypt(ctx context.Context, keyId string, plainStr string) (string, error)
+	Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error)
+}
+
+// kmsCipher supports basic Encrypt & Decrypt methods.
+type kmsCipher struct {
+	Client KMSCipher
 }
 
 // NewKMSCipher creates a new kms cipher for the specific "region" and "keyid".
-func NewKMSCipher(region string) *KMSCipher {
+func NewKMSCipher(region string) *kmsCipher {
 	client := newAWSKMSClient(region)
-	return &KMSCipher{client}
+	return NewKMSCipherWithClient(client)
 }
 
 // NewKMSCipherWithClient creates a new kms cipher for the specific "region" and "keyid".
-func NewKMSCipherWithClient(client KMSClient) *KMSCipher {
-	return &KMSCipher{client}
+func NewKMSCipherWithClient(client KMSCipher) *kmsCipher {
+	return &kmsCipher{client}
 }
 
 // Encrypt will encrypt the "plainStr" using the region and keyID of the cipher.
-func (c *KMSCipher) Encrypt(ctx context.Context, keyID string, plainStr string) (string, error) {
+func (c *kmsCipher) Encrypt(ctx context.Context, keyID string, plainStr string) (string, error) {
 	return c.Client.Encrypt(ctx, keyID, plainStr)
 }
 
 // Decrypt will decrypt the "encryptedStr" using the region and keyID of the cipher.
-func (c *KMSCipher) Decrypt(ctx context.Context, keyID string, encryptedStr string) (string, error) {
+func (c *kmsCipher) Decrypt(ctx context.Context, keyID string, encryptedStr string) (string, error) {
 	return c.Client.Decrypt(ctx, keyID, encryptedStr)
 }

--- a/cipher/kms_test.go
+++ b/cipher/kms_test.go
@@ -15,6 +15,14 @@ const (
 	testRegion = "us-west-1"
 )
 
+func TestNewKMSCipher(t *testing.T) {
+	cipher := NewKMSCipher("region")
+	assert.NotNil(t, cipher)
+
+	cipher = NewKMSCipherWithClient(&mockKMSClient{})
+	assert.NotNil(t, cipher)
+}
+
 func TestEncrypt(t *testing.T) {
 	strInput := "inputStr"
 	ctx := context.Background()

--- a/cipher/package.go
+++ b/cipher/package.go
@@ -5,10 +5,10 @@ import (
 	"os"
 )
 
-var DefaultKMSCipher *KMSCipher = getInstance()
+var DefaultKMSCipher KMSCipher = getInstance()
 
-func getInstance() *KMSCipher {
-	var client KMSClient
+func getInstance() *kmsCipher {
+	var client KMSCipher
 
 	region := os.Getenv("AWS_REGION")
 	client = newAWSKMSClient(region)

--- a/cipher/package_test.go
+++ b/cipher/package_test.go
@@ -13,10 +13,10 @@ func TestPackageEncrypt(t *testing.T) {
 	keyId := "arn:aws:kms:us-west-2:111122223333:key/1234abcd-12ab-34cd-56ef-1234567890ab"
 
 	// replace the package level client with our mock
-	stdClient := cipher.DefaultKMSCipher.Client
-	cipher.DefaultKMSCipher.Client = newMockedCipherClient()
+	stdCipher := cipher.DefaultKMSCipher
+	cipher.DefaultKMSCipher = newMockedCipherClient()
 	defer func() {
-		cipher.DefaultKMSCipher.Client = stdClient
+		cipher.DefaultKMSCipher = stdCipher
 	}()
 
 	cipherText, err := cipher.Encrypt(ctx, keyId, "test_plain_str")


### PR DESCRIPTION
Purpose:
- Improve test coverage of the cipher package
- Allow kms.Options (as vararg) so that we can mock the HttpClient and Retryer to by-pass network calls to AWS