### PR TITLE
Enforce Properties for custom fields

### DIFF
--- a/log/fields.go
+++ b/log/fields.go
@@ -1,0 +1,67 @@
+package log
+
+import (
+	"net"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// Field contains an element of the log, usually a key-value pair.
+type Field struct {
+	impl *zerolog.Event
+}
+
+func newLoggerField(impl *zerolog.Event) *Field {
+	return &Field{impl: impl}
+}
+
+// SubDoc creates a new sub-document with in list of log properties.
+func SubDoc() *Field {
+	subDoc := zerolog.Dict()
+	return newLoggerField(subDoc)
+}
+
+// Str adds the property key with val as a string to the log.
+func (lf *Field) Str(key string, val string) *Field {
+	lf.impl = lf.impl.Str(key, val)
+	return lf
+}
+
+// Int adds the property key with val as an int to the log.
+func (lf *Field) Int(key string, val int) *Field {
+	lf.impl = lf.impl.Int(key, val)
+	return lf
+}
+
+// Bool adds the property key with val as an bool to the log.
+func (lf *Field) Bool(key string, b bool) *Field {
+	lf.impl = lf.impl.Bool(key, b)
+	return lf
+}
+
+// Duration adds the property key with val as an time.Duration to the log.
+func (lf *Field) Duration(key string, d time.Duration) *Field {
+	lf.impl = lf.impl.Dur(key, d)
+	return lf
+}
+
+// Time adds the property key with val as an uuid.UUID to the log.
+func (lf *Field) Time(key string, t time.Time) *Field {
+	// uses zerolog.TimeFieldFormat which we set to time.RFC3339
+	lf.impl = lf.impl.Time(key, t)
+	return lf
+}
+
+// IPAddr adds the property key with val as an net.IP to the log.
+func (lf *Field) IPAddr(key string, ip net.IP) *Field {
+	lf.impl = lf.impl.IPAddr(key, ip)
+	return lf
+}
+
+// UUID adds the property key with val as an uuid.UUID to the log.
+func (lf *Field) UUID(key string, uuid uuid.UUID) *Field {
+	lf.impl = lf.impl.Str(key, uuid.String())
+	return lf
+}

--- a/log/logger.go
+++ b/log/logger.go
@@ -40,7 +40,7 @@ func NewLogger(config *Config) *standardLogger {
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Debug(event string) *Property {
 	le := l.impl.Debug().Str("event", toSnakeCase(event))
-	return &Property{le}
+	return newLoggerProperty(le)
 }
 
 // Info starts a new message with info level.
@@ -48,7 +48,7 @@ func (l *standardLogger) Debug(event string) *Property {
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Info(event string) *Property {
 	le := l.impl.Info().Str("event", toSnakeCase(event))
-	return &Property{le}
+	return newLoggerProperty(le)
 }
 
 // Warn starts a new message with warn level.
@@ -56,7 +56,7 @@ func (l *standardLogger) Info(event string) *Property {
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Warn(event string) *Property {
 	le := l.impl.Warn().Str("event", toSnakeCase(event))
-	return &Property{le}
+	return newLoggerProperty(le)
 }
 
 // Error starts a new message with error level.
@@ -66,8 +66,8 @@ func (l *standardLogger) Error(event string, err error) *Property {
 	le := l.impl.Error().
 		Err(err).
 		Str("event", toSnakeCase(event))
-	fields := &Property{le}
-	return fields.withFullStack()
+	props := newLoggerProperty(le)
+	return props.withFullStack()
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function
@@ -76,7 +76,7 @@ func (l *standardLogger) Error(event string, err error) *Property {
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Fatal(event string, err error) *Property {
 	le := l.impl.Fatal().Err(err).Str("event", toSnakeCase(event))
-	return &Property{le}
+	return newLoggerProperty(le)
 }
 
 // Panic starts a new message with panic level. The panic() function
@@ -85,5 +85,5 @@ func (l *standardLogger) Fatal(event string, err error) *Property {
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Panic(event string, err error) *Property {
 	le := l.impl.Panic().Err(err).Str("event", toSnakeCase(event))
-	return &Property{le}
+	return newLoggerProperty(le)
 }

--- a/log/package_test.go
+++ b/log/package_test.go
@@ -19,7 +19,8 @@ func TestMockedPackageLogger(t *testing.T) {
 	mockLogger := new(mockLogger)
 	log.DefaultLogger = mockLogger
 
-	mockLogger.On("Debug", "should_call_mock").Return(log.SubDoc())
+	nilProperty := &log.Property{}
+	mockLogger.On("Debug", "should_call_mock").Return(nilProperty)
 
 	log.Debug("should_call_mock").
 		Properties(log.SubDoc().

--- a/log/properties.go
+++ b/log/properties.go
@@ -1,10 +1,6 @@
 package log
 
 import (
-	"net"
-	"time"
-
-	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 )
 
@@ -13,63 +9,13 @@ type Property struct {
 	impl *zerolog.Event
 }
 
-func newLoggerField(impl *zerolog.Event) *Property {
+func newLoggerProperty(impl *zerolog.Event) *Property {
 	return &Property{impl: impl}
 }
 
-// SubDoc creates a new sub-document with in list of log properties.
-func SubDoc() *Property {
-	subDoc := zerolog.Dict()
-	return newLoggerField(subDoc)
-}
-
-// Str adds the property key with val as a string to the log.
-func (lf *Property) Str(key string, val string) *Property {
-	lf.impl = lf.impl.Str(key, val)
-	return lf
-}
-
-// Int adds the property key with val as an int to the log.
-func (lf *Property) Int(key string, val int) *Property {
-	lf.impl = lf.impl.Int(key, val)
-	return lf
-}
-
-// Bool adds the property key with val as an bool to the log.
-func (lf *Property) Bool(key string, b bool) *Property {
-	lf.impl = lf.impl.Bool(key, b)
-	return lf
-}
-
-// Duration adds the property key with val as an time.Duration to the log.
-func (lf *Property) Duration(key string, d time.Duration) *Property {
-	lf.impl = lf.impl.Dur(key, d)
-	return lf
-}
-
-// Time adds the property key with val as an uuid.UUID to the log.
-func (lf *Property) Time(key string, t time.Time) *Property {
-	// uses zerolog.TimeFieldFormat which we set to time.RFC3339
-	lf.impl = lf.impl.Time(key, t)
-	return lf
-}
-
-// IPAddr adds the property key with val as an net.IP to the log.
-func (lf *Property) IPAddr(key string, ip net.IP) *Property {
-	lf.impl = lf.impl.IPAddr(key, ip)
-	return lf
-}
-
-// UUID adds the property key with val as an uuid.UUID to the log.
-func (lf *Property) UUID(key string, uuid uuid.UUID) *Property {
-	lf.impl = lf.impl.Str(key, uuid.String())
-	return lf
-}
-
 // Properties adds an entire sub-document of type Property to the log.
-func (lf *Property) Properties(props *Property) *Property {
-	lf.impl = lf.impl.Dict("properties", props.impl)
-	return lf
+func (lf *Property) Properties(fields *Field) *Property {
+	return lf.doc("properties", fields)
 }
 
 // Details adds the property 'details' with the val as a string to the log.
@@ -100,8 +46,8 @@ func (lf *Property) Send() {
 	lf.impl.Send()
 }
 
-func (lf *Property) doc(key string, props *Property) *Property {
-	lf.impl = lf.impl.Dict(key, props.impl)
+func (lf *Property) doc(key string, fields *Field) *Property {
+	lf.impl = lf.impl.Dict(key, fields.impl)
 	return lf
 }
 


### PR DESCRIPTION
Purpose: Stop accidental non-compliance of the logging eng std with missing "Properties" for custom log fields.

Currently, this is allowed:
log.Debug("hander_added").Str("resource", "resource_id").Int("test-number", 1).Details("detailed information explain")

But this PR changes this so that the above will no longer compile and force engineers to use:

log.Debug("hander_added").
		Properties(log.SubDoc().
			Str("resource", "resource_id").
			Int("test-number", 1),
		).Details("detailed information explain")

