### PR TITLE
Testable JWT package level methods

### DIFF
--- a/jwt/JWT.md
+++ b/jwt/JWT.md
@@ -121,29 +121,8 @@ func ExampleMocked_EncoderDecoder() {
 		err,
 	)
 
-	// To create a specific instance of the encoder and decoder you can use the following
-	privateKeyBytes, err := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
-	encoder, err := jwt.NewJwtEncoder(string(privateKeyBytes), webGatewayKid)
-
-	token, err = encoder.Encode(claims)
-	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
-
-	b, err := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
-	decoder, err := jwt.NewJwtDecoder(string(b))
-
-	claim, err = decoder.Decode(token)
-	fmt.Printf(
-		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
-		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
-		claim.Issuer, claim.Subject, claim.Audience,
-		claim.ExpiresAt.UTC().Format(time.RFC3339),
-		err,
-	)
-
 	// Output:
 	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0' (err='<nil>')
-	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
-	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.CH_UIzR_W1275ffAUES0EzsHNRYZyBbrLsKQBbfJ6DpsLW3HAxH5RSjzXL_yCGTrbcHytTYLIZKhN37lC9BZdhkxZtR9bMqqGu4K0zHNtztoC5u1P7kc81FX_dPi9aiR7B4hruSfOFHoWM1A_D_i55qPAJlB0LRFf4nwX9FIWt2IIMwSGUcxfjFYE7MKTlzP3heCYNVzIxLD5g5gcoIyttmltiD_bBvObvExuDsJSlxwrAYvKc2cpIsh1MZ1x16uhG-du2_YdfSK6Ykd6aAvVpq3IGkb99SKS3xUsCV3JkSDRIcWMKzPhEh_huDV4Z3AA3jA4sWvR20WOqzaW3dRAoYIYL7kP92PrXX8m0EtLPAlX471POgNREWqdmxrbdkZcYNHqrmHcAsMRPMXcZ15tH8_-jIDUvGpNbcetgmQRjcpLtyniN_Ag4kGoPhYzGLx6122DEBrYf0Os5TQcRAzAoSF1n_43hsfmuGw00ey3ye5siJle7LN8EHUAXjegrpC7WTFF_eIsOtkuXTJx6OMmuggRvlMaCughYP6IvoIXD7ME0DnzmuvANID9yo-X8DJpMiWbZ2_edCE7dmuqxIZOqJmTolswQs1p0hzFyaX5SrEgcGjHxwTpuCYfaQ7qrbz2D_OQfXbglbk4e8Hm63bGmmz9bKV4KDBVPJO1zOGLtM' (err='<nil>')
 	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
 }
 

--- a/jwt/JWT.md
+++ b/jwt/JWT.md
@@ -61,3 +61,110 @@ func BasicExamples() {
 	fmt.Printf("The decode token is '%v' (err='%+v')\n", sc, err)
 }
 ```
+
+
+## Testing and Mocks
+
+During tests you can override the package level `DefaultJwtEncoder` and/or `DefaultJwtDecoder` with a mock that supports 
+the `Encoder` or `Decoder` interface.
+
+- Encode(claims *StandardClaims) (string, error)
+- Decode(tokenString string) (*StandardClaims, error)
+
+```
+import (
+	"context"
+	"testing"
+
+	"github.com/cultureamp/ca-go/jwt"
+	"github.com/stretchr/testify/mock"
+)
+
+func ExampleMocked_EncoderDecoder() {
+	claims := &jwt.StandardClaims{
+		AccountId:       "abc123",
+		RealUserId:      "xyz234",
+		EffectiveUserId: "xyz345",
+		Issuer:          "encoder-name",
+		Subject:         "test",
+		Audience:        []string{"decoder-name"},
+		ExpiresAt:       time.Unix(2211797532, 0), //  2/2/2040
+		IssuedAt:        time.Unix(1580608922, 0), // 1/1/2020
+		NotBefore:       time.Unix(1580608922, 0), // 1/1/2020
+	}
+
+	mockEncDec := newMockedEncoderDecoder()
+	mockEncDec.On("Encode", mock.Anything).Return("eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0", nil)
+	mockEncDec.On("Decode", mock.Anything).Return(claims, nil)
+
+	// Overwrite the Default package level encoder and decoder
+	oldEncoder := jwt.DefaultJwtEncoder
+	oldDecoder := jwt.DefaultJwtDecoder
+	jwt.DefaultJwtEncoder = mockEncDec
+	jwt.DefaultJwtDecoder = mockEncDec
+	defer func() {
+		jwt.DefaultJwtEncoder = oldEncoder
+		jwt.DefaultJwtDecoder = oldDecoder
+	}()
+
+	// Encode this claim with the default "web-gateway" key and add the kid to the token header
+	token, err := jwt.Encode(claims)
+	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
+
+	// Decode it back again using the key that matches the kid header using the default JWKS JSON keys
+	claim, err := jwt.Decode(token)
+	fmt.Printf(
+		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
+		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
+		claim.Issuer, claim.Subject, claim.Audience,
+		claim.ExpiresAt.UTC().Format(time.RFC3339),
+		err,
+	)
+
+	// To create a specific instance of the encoder and decoder you can use the following
+	privateKeyBytes, err := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
+	encoder, err := jwt.NewJwtEncoder(string(privateKeyBytes), webGatewayKid)
+
+	token, err = encoder.Encode(claims)
+	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
+
+	b, err := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
+	decoder, err := jwt.NewJwtDecoder(string(b))
+
+	claim, err = decoder.Decode(token)
+	fmt.Printf(
+		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
+		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
+		claim.Issuer, claim.Subject, claim.Audience,
+		claim.ExpiresAt.UTC().Format(time.RFC3339),
+		err,
+	)
+
+	// Output:
+	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0' (err='<nil>')
+	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
+	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.CH_UIzR_W1275ffAUES0EzsHNRYZyBbrLsKQBbfJ6DpsLW3HAxH5RSjzXL_yCGTrbcHytTYLIZKhN37lC9BZdhkxZtR9bMqqGu4K0zHNtztoC5u1P7kc81FX_dPi9aiR7B4hruSfOFHoWM1A_D_i55qPAJlB0LRFf4nwX9FIWt2IIMwSGUcxfjFYE7MKTlzP3heCYNVzIxLD5g5gcoIyttmltiD_bBvObvExuDsJSlxwrAYvKc2cpIsh1MZ1x16uhG-du2_YdfSK6Ykd6aAvVpq3IGkb99SKS3xUsCV3JkSDRIcWMKzPhEh_huDV4Z3AA3jA4sWvR20WOqzaW3dRAoYIYL7kP92PrXX8m0EtLPAlX471POgNREWqdmxrbdkZcYNHqrmHcAsMRPMXcZ15tH8_-jIDUvGpNbcetgmQRjcpLtyniN_Ag4kGoPhYzGLx6122DEBrYf0Os5TQcRAzAoSF1n_43hsfmuGw00ey3ye5siJle7LN8EHUAXjegrpC7WTFF_eIsOtkuXTJx6OMmuggRvlMaCughYP6IvoIXD7ME0DnzmuvANID9yo-X8DJpMiWbZ2_edCE7dmuqxIZOqJmTolswQs1p0hzFyaX5SrEgcGjHxwTpuCYfaQ7qrbz2D_OQfXbglbk4e8Hm63bGmmz9bKV4KDBVPJO1zOGLtM' (err='<nil>')
+	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
+}
+
+type mockedEncoderDecoder struct {
+	mock.Mock
+}
+
+func newMockedEncoderDecoder() *mockedEncoderDecoder {
+	return &mockedEncoderDecoder{}
+}
+
+func (m *mockedEncoderDecoder) Encode(claims *jwt.StandardClaims) (string, error) {
+	args := m.Called(claims)
+	output, _ := args.Get(0).(string)
+	return output, args.Error(1)
+}
+
+// Decrypt on the test runner just returns the "encryptedStr" as the decrypted plainstr.
+func (m *mockedEncoderDecoder) Decode(tokenString string) (*jwt.StandardClaims, error) {
+	args := m.Called(tokenString)
+	output, _ := args.Get(0).(*jwt.StandardClaims)
+	return output, args.Error(1)
+}
+```

--- a/jwt/jwt_example_test.go
+++ b/jwt/jwt_example_test.go
@@ -67,7 +67,7 @@ func Example() {
 	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
 }
 
-func ExampleMocked_EncoderDecoder() {
+func ExampleDefaultJwtEncoder() {
 	claims := &jwt.StandardClaims{
 		AccountId:       "abc123",
 		RealUserId:      "xyz234",
@@ -82,43 +82,47 @@ func ExampleMocked_EncoderDecoder() {
 
 	mockEncDec := newMockedEncoderDecoder()
 	mockEncDec.On("Encode", mock.Anything).Return("eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0", nil)
-	mockEncDec.On("Decode", mock.Anything).Return(claims, nil)
 
 	// Overwrite the Default package level encoder and decoder
 	oldEncoder := jwt.DefaultJwtEncoder
-	oldDecoder := jwt.DefaultJwtDecoder
 	jwt.DefaultJwtEncoder = mockEncDec
-	jwt.DefaultJwtDecoder = mockEncDec
 	defer func() {
 		jwt.DefaultJwtEncoder = oldEncoder
-		jwt.DefaultJwtDecoder = oldDecoder
 	}()
 
 	// Encode this claim with the default "web-gateway" key and add the kid to the token header
 	token, err := jwt.Encode(claims)
 	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
 
+	// Output:
+	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0' (err='<nil>')
+}
+
+func ExampleDefaultJwtDecoder() {
+	claims := &jwt.StandardClaims{
+		AccountId:       "abc123",
+		RealUserId:      "xyz234",
+		EffectiveUserId: "xyz345",
+		Issuer:          "encoder-name",
+		Subject:         "test",
+		Audience:        []string{"decoder-name"},
+		ExpiresAt:       time.Unix(2211797532, 0), //  2/2/2040
+		IssuedAt:        time.Unix(1580608922, 0), // 1/1/2020
+		NotBefore:       time.Unix(1580608922, 0), // 1/1/2020
+	}
+
+	mockEncDec := newMockedEncoderDecoder()
+	mockEncDec.On("Decode", mock.Anything).Return(claims, nil)
+
+	// Overwrite the Default package level encoder and decoder
+	oldDecoder := jwt.DefaultJwtDecoder
+	jwt.DefaultJwtDecoder = mockEncDec
+	defer func() {
+		jwt.DefaultJwtDecoder = oldDecoder
+	}()
+
 	// Decode it back again using the key that matches the kid header using the default JWKS JSON keys
-	claim, err := jwt.Decode(token)
-	fmt.Printf(
-		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
-		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
-		claim.Issuer, claim.Subject, claim.Audience,
-		claim.ExpiresAt.UTC().Format(time.RFC3339),
-		err,
-	)
-
-	// To create a specific instance of the encoder and decoder you can use the following
-	privateKeyBytes, err := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
-	encoder, err := jwt.NewJwtEncoder(string(privateKeyBytes), webGatewayKid)
-
-	token, err = encoder.Encode(claims)
-	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
-
-	b, err := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
-	decoder, err := jwt.NewJwtDecoder(string(b))
-
-	claim, err = decoder.Decode(token)
+	claim, err := jwt.Decode("eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0")
 	fmt.Printf(
 		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
 		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
@@ -128,9 +132,6 @@ func ExampleMocked_EncoderDecoder() {
 	)
 
 	// Output:
-	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0' (err='<nil>')
-	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
-	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.CH_UIzR_W1275ffAUES0EzsHNRYZyBbrLsKQBbfJ6DpsLW3HAxH5RSjzXL_yCGTrbcHytTYLIZKhN37lC9BZdhkxZtR9bMqqGu4K0zHNtztoC5u1P7kc81FX_dPi9aiR7B4hruSfOFHoWM1A_D_i55qPAJlB0LRFf4nwX9FIWt2IIMwSGUcxfjFYE7MKTlzP3heCYNVzIxLD5g5gcoIyttmltiD_bBvObvExuDsJSlxwrAYvKc2cpIsh1MZ1x16uhG-du2_YdfSK6Ykd6aAvVpq3IGkb99SKS3xUsCV3JkSDRIcWMKzPhEh_huDV4Z3AA3jA4sWvR20WOqzaW3dRAoYIYL7kP92PrXX8m0EtLPAlX471POgNREWqdmxrbdkZcYNHqrmHcAsMRPMXcZ15tH8_-jIDUvGpNbcetgmQRjcpLtyniN_Ag4kGoPhYzGLx6122DEBrYf0Os5TQcRAzAoSF1n_43hsfmuGw00ey3ye5siJle7LN8EHUAXjegrpC7WTFF_eIsOtkuXTJx6OMmuggRvlMaCughYP6IvoIXD7ME0DnzmuvANID9yo-X8DJpMiWbZ2_edCE7dmuqxIZOqJmTolswQs1p0hzFyaX5SrEgcGjHxwTpuCYfaQ7qrbz2D_OQfXbglbk4e8Hm63bGmmz9bKV4KDBVPJO1zOGLtM' (err='<nil>')
 	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
 }
 

--- a/jwt/jwt_example_test.go
+++ b/jwt/jwt_example_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cultureamp/ca-go/jwt"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -64,4 +65,92 @@ func Example() {
 	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
 	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.CH_UIzR_W1275ffAUES0EzsHNRYZyBbrLsKQBbfJ6DpsLW3HAxH5RSjzXL_yCGTrbcHytTYLIZKhN37lC9BZdhkxZtR9bMqqGu4K0zHNtztoC5u1P7kc81FX_dPi9aiR7B4hruSfOFHoWM1A_D_i55qPAJlB0LRFf4nwX9FIWt2IIMwSGUcxfjFYE7MKTlzP3heCYNVzIxLD5g5gcoIyttmltiD_bBvObvExuDsJSlxwrAYvKc2cpIsh1MZ1x16uhG-du2_YdfSK6Ykd6aAvVpq3IGkb99SKS3xUsCV3JkSDRIcWMKzPhEh_huDV4Z3AA3jA4sWvR20WOqzaW3dRAoYIYL7kP92PrXX8m0EtLPAlX471POgNREWqdmxrbdkZcYNHqrmHcAsMRPMXcZ15tH8_-jIDUvGpNbcetgmQRjcpLtyniN_Ag4kGoPhYzGLx6122DEBrYf0Os5TQcRAzAoSF1n_43hsfmuGw00ey3ye5siJle7LN8EHUAXjegrpC7WTFF_eIsOtkuXTJx6OMmuggRvlMaCughYP6IvoIXD7ME0DnzmuvANID9yo-X8DJpMiWbZ2_edCE7dmuqxIZOqJmTolswQs1p0hzFyaX5SrEgcGjHxwTpuCYfaQ7qrbz2D_OQfXbglbk4e8Hm63bGmmz9bKV4KDBVPJO1zOGLtM' (err='<nil>')
 	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
+}
+
+func ExampleMocked_EncoderDecoder() {
+	claims := &jwt.StandardClaims{
+		AccountId:       "abc123",
+		RealUserId:      "xyz234",
+		EffectiveUserId: "xyz345",
+		Issuer:          "encoder-name",
+		Subject:         "test",
+		Audience:        []string{"decoder-name"},
+		ExpiresAt:       time.Unix(2211797532, 0), //  2/2/2040
+		IssuedAt:        time.Unix(1580608922, 0), // 1/1/2020
+		NotBefore:       time.Unix(1580608922, 0), // 1/1/2020
+	}
+
+	mockEncDec := newMockedEncoderDecoder()
+	mockEncDec.On("Encode", mock.Anything).Return("eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0", nil)
+	mockEncDec.On("Decode", mock.Anything).Return(claims, nil)
+
+	// Overwrite the Default package level encoder and decoder
+	oldEncoder := jwt.DefaultJwtEncoder
+	oldDecoder := jwt.DefaultJwtDecoder
+	jwt.DefaultJwtEncoder = mockEncDec
+	jwt.DefaultJwtDecoder = mockEncDec
+	defer func() {
+		jwt.DefaultJwtEncoder = oldEncoder
+		jwt.DefaultJwtDecoder = oldDecoder
+	}()
+
+	// Encode this claim with the default "web-gateway" key and add the kid to the token header
+	token, err := jwt.Encode(claims)
+	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
+
+	// Decode it back again using the key that matches the kid header using the default JWKS JSON keys
+	claim, err := jwt.Decode(token)
+	fmt.Printf(
+		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
+		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
+		claim.Issuer, claim.Subject, claim.Audience,
+		claim.ExpiresAt.UTC().Format(time.RFC3339),
+		err,
+	)
+
+	// To create a specific instance of the encoder and decoder you can use the following
+	privateKeyBytes, err := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
+	encoder, err := jwt.NewJwtEncoder(string(privateKeyBytes), webGatewayKid)
+
+	token, err = encoder.Encode(claims)
+	fmt.Printf("The encoded token is '%s' (err='%v')\n", token, err)
+
+	b, err := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
+	decoder, err := jwt.NewJwtDecoder(string(b))
+
+	claim, err = decoder.Decode(token)
+	fmt.Printf(
+		"The decoded token is '%s %s %s %s %v %s %s' (err='%+v')\n",
+		claim.AccountId, claim.RealUserId, claim.EffectiveUserId,
+		claim.Issuer, claim.Subject, claim.Audience,
+		claim.ExpiresAt.UTC().Format(time.RFC3339),
+		err,
+	)
+
+	// Output:
+	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0' (err='<nil>')
+	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
+	// The encoded token is 'eyJhbGciOiJSUzUxMiIsImtpZCI6IndlYi1nYXRld2F5IiwidHlwIjoiSldUIn0.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.CH_UIzR_W1275ffAUES0EzsHNRYZyBbrLsKQBbfJ6DpsLW3HAxH5RSjzXL_yCGTrbcHytTYLIZKhN37lC9BZdhkxZtR9bMqqGu4K0zHNtztoC5u1P7kc81FX_dPi9aiR7B4hruSfOFHoWM1A_D_i55qPAJlB0LRFf4nwX9FIWt2IIMwSGUcxfjFYE7MKTlzP3heCYNVzIxLD5g5gcoIyttmltiD_bBvObvExuDsJSlxwrAYvKc2cpIsh1MZ1x16uhG-du2_YdfSK6Ykd6aAvVpq3IGkb99SKS3xUsCV3JkSDRIcWMKzPhEh_huDV4Z3AA3jA4sWvR20WOqzaW3dRAoYIYL7kP92PrXX8m0EtLPAlX471POgNREWqdmxrbdkZcYNHqrmHcAsMRPMXcZ15tH8_-jIDUvGpNbcetgmQRjcpLtyniN_Ag4kGoPhYzGLx6122DEBrYf0Os5TQcRAzAoSF1n_43hsfmuGw00ey3ye5siJle7LN8EHUAXjegrpC7WTFF_eIsOtkuXTJx6OMmuggRvlMaCughYP6IvoIXD7ME0DnzmuvANID9yo-X8DJpMiWbZ2_edCE7dmuqxIZOqJmTolswQs1p0hzFyaX5SrEgcGjHxwTpuCYfaQ7qrbz2D_OQfXbglbk4e8Hm63bGmmz9bKV4KDBVPJO1zOGLtM' (err='<nil>')
+	// The decoded token is 'abc123 xyz234 xyz345 encoder-name test [decoder-name] 2040-02-02T12:12:12Z' (err='<nil>')
+}
+
+type mockedEncoderDecoder struct {
+	mock.Mock
+}
+
+func newMockedEncoderDecoder() *mockedEncoderDecoder {
+	return &mockedEncoderDecoder{}
+}
+
+func (m *mockedEncoderDecoder) Encode(claims *jwt.StandardClaims) (string, error) {
+	args := m.Called(claims)
+	output, _ := args.Get(0).(string)
+	return output, args.Error(1)
+}
+
+// Decrypt on the test runner just returns the "encryptedStr" as the decrypted plainstr.
+func (m *mockedEncoderDecoder) Decode(tokenString string) (*jwt.StandardClaims, error) {
+	args := m.Called(tokenString)
+	output, _ := args.Get(0).(*jwt.StandardClaims)
+	return output, args.Error(1)
 }


### PR DESCRIPTION
Allow package level default encoder and decoder to be mocked