### PR TITLE
do not log empty Str values

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,8 +2,6 @@ run:
   go: 1.21
   timeout: 5m
   tests: false
-  skip-dirs:
-    - kafkatest
 
 linters:
   disable-all: true
@@ -225,6 +223,9 @@ linters-settings:
         mode: strict
 
 issues:
+  exclude-dirs:
+    - kafkatest
+
   exclude-rules:
 
     # too hard to refactor

--- a/log/extensions_test.go
+++ b/log/extensions_test.go
@@ -45,7 +45,7 @@ func ExampleLogger_Info_withRequestTracing() {
 
 	// Output:
 	// 2020-11-14T11:30:32Z INF event="logging should not contain request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
-	// 2020-11-14T11:30:32Z INF event="logging should log empty request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_missing_headers_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1} tracing={"correlation_id":"","request_id":"","trace_id":""}
+	// 2020-11-14T11:30:32Z INF event="logging should log empty request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_missing_headers_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1} tracing={}
 	// 2020-11-14T11:30:32Z INF event="logging should contain request tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_request_tracing farm=local product= properties={"resource":"resource_id","test-number":1} tracing={"correlation_id":"correlation_789_id","request_id":"request_456_id","trace_id":"trace_123_id"}
 }
 
@@ -83,8 +83,8 @@ func ExampleLogger_Info_withRequestDiagnostics() {
 
 	// Output:
 	// 2020-11-14T11:30:32Z INF event="logging should not contain request diagnostics" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_request_diagnostics farm=local product= properties={"resource":"resource_id","test-number":1}
-	// 2020-11-14T11:30:32Z INF event="logging should log minimal request diagnostics" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_minimal_url_request_diagnostics farm=local product= properties={"resource":"resource_id","test-number":1} request={"fragment":"","host":"example.com","method":"GET","path":"","proto":"HTTP/1.1","query":"","scheme":"http"}
-	// 2020-11-14T11:30:32Z INF event="logging should contain request diagnostics" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_request_diagnostics farm=local product= properties={"resource":"resource_id","test-number":1} request={"fragment":"","host":"example.com","method":"GET","path":"/foo","proto":"HTTP/1.1","query":"arg=value#fragment-1","scheme":"https"}
+	// 2020-11-14T11:30:32Z INF event="logging should log minimal request diagnostics" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_minimal_url_request_diagnostics farm=local product= properties={"resource":"resource_id","test-number":1} request={"host":"example.com","method":"GET","proto":"HTTP/1.1","scheme":"http"}
+	// 2020-11-14T11:30:32Z INF event="logging should contain request diagnostics" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_request_diagnostics farm=local product= properties={"resource":"resource_id","test-number":1} request={"host":"example.com","method":"GET","path":"/foo","proto":"HTTP/1.1","query":"arg=value#fragment-1","scheme":"https"}
 }
 
 func ExampleLogger_Info_withAuthenticationUserTracing() {
@@ -125,7 +125,7 @@ func ExampleLogger_Info_withAuthenticationUserTracing() {
 
 	// Output:
 	// 2020-11-14T11:30:32Z INF event="logging should not contain authN tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
-	// 2020-11-14T11:30:32Z INF event="logging should log empty authN tracing" app= app_version=1.0.0 authentication={"account_id":"","realuser_id":"","user_id":""} aws_account_id=development aws_region= event=info_with_missing_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2020-11-14T11:30:32Z INF event="logging should log empty authN tracing" app= app_version=1.0.0 authentication={} aws_account_id=development aws_region= event=info_with_missing_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
 	// 2020-11-14T11:30:32Z INF event="logging should contain authN tracing" app= app_version=1.0.0 authentication={"account_id":"account_123_id","realuser_id":"real_456_id","user_id":"user_789_id"} aws_account_id=development aws_region= event=info_with_auth_n_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
 }
 
@@ -166,7 +166,7 @@ func ExampleLogger_Info_withAuthorizationTracing() {
 
 	// Output:
 	// 2020-11-14T11:30:32Z INF event="logging should not contain authZ tracing" app= app_version=1.0.0 aws_account_id=development aws_region= event=info_with_nil_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
-	// 2020-11-14T11:30:32Z INF event="logging should log empty authZ tracing" app= app_version=1.0.0 authorization={"authorization_token":"","user_agent":"","x_forwarded_for":"","xca_service_authorization_token":""} aws_account_id=development aws_region= event=info_with_missing_headers_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
+	// 2020-11-14T11:30:32Z INF event="logging should log empty authZ tracing" app= app_version=1.0.0 authorization={} aws_account_id=development aws_region= event=info_with_missing_headers_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
 	// 2020-11-14T11:30:32Z INF event="logging should contain authZ tracing" app= app_version=1.0.0 authorization={"authorization_token":"AWS**********ken","user_agent":"node","x_forwarded_for":"123.123.123","xca_service_authorization_token":"Bear**********oken"} aws_account_id=development aws_region= event=info_with_auth_z_tracing farm=local product= properties={"resource":"resource_id","test-number":1}
 }
 

--- a/log/fields.go
+++ b/log/fields.go
@@ -24,7 +24,12 @@ func Add() *Field {
 }
 
 // Str adds the property key with val as a string to the log.
+// Note: Empty string values will not be logged.
 func (lf *Field) Str(key string, val string) *Field {
+	if val == "" {
+		return lf
+	}
+
 	lf.impl = lf.impl.Str(key, val)
 	return lf
 }


### PR DESCRIPTION
Purpose: Cleaned up logging after web-gateway deployment.

Changes:
- Now we don't log empty string values
- Fixed golangci warning "WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. "