### PR TITLE
Cipher comment updates

### DIFF
--- a/cipher/CIPHER.md
+++ b/cipher/CIPHER.md
@@ -10,8 +10,10 @@ The encrypted string will be a base64 string and look something like: `AQICAHgk4
 
 ## Environment Variables
 
-Here is the list of supported environment variables currently supported:
+Here is the list of mandatory environment variables that MUST be set for this package:
 - AwsRegionEnv    = "AWS_REGION"
+
+Failure to set these will result in a panic() at start up.
 
 ## Methods
 

--- a/cipher/client.go
+++ b/cipher/client.go
@@ -19,6 +19,7 @@ func newAWSKMSClient(region string, optFns ...func(*kms.Options)) *awsKMSClient 
 	}
 }
 
+// Encrypt will use the KMS keyId to encrypt the plainStr and return it as a base64 encoded string.
 func (c *awsKMSClient) Encrypt(ctx context.Context, keyId string, plainStr string) (string, error) {
 	input := &kms.EncryptInput{
 		KeyId:     &keyId,
@@ -34,6 +35,7 @@ func (c *awsKMSClient) Encrypt(ctx context.Context, keyId string, plainStr strin
 	return blobString, nil
 }
 
+// Decrpyt will use the KMS keyId and the base64 encoded encryptedStr and return it decrypted as a plain string.
 func (c *awsKMSClient) Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error) {
 	blob, err := b64.StdEncoding.DecodeString(encryptedStr)
 	if err != nil {

--- a/cipher/kms.go
+++ b/cipher/kms.go
@@ -15,23 +15,24 @@ type kmsCipher struct {
 	Client KMSCipher
 }
 
-// NewKMSCipher creates a new kms cipher for the specific "region" and "keyid".
+// NewKMSCipher creates a new kms cipher for the specific "region".
 func NewKMSCipher(region string) *kmsCipher {
 	client := newAWSKMSClient(region)
 	return NewKMSCipherWithClient(client)
 }
 
-// NewKMSCipherWithClient creates a new kms cipher for the specific "region" and "keyid".
+// NewKMSCipherWithClient creates a new kms cipher using a specific client that supports the KMSCipher interface.
+// This is provided mostly for testing purposes.
 func NewKMSCipherWithClient(client KMSCipher) *kmsCipher {
 	return &kmsCipher{client}
 }
 
-// Encrypt will encrypt the "plainStr" using the region and keyID of the cipher.
+// Encrypt will use the KMS keyId to encrypt the plainStr and return it as a base64 encoded string.
 func (c *kmsCipher) Encrypt(ctx context.Context, keyID string, plainStr string) (string, error) {
 	return c.Client.Encrypt(ctx, keyID, plainStr)
 }
 
-// Decrypt will decrypt the "encryptedStr" using the region and keyID of the cipher.
+// Decrpyt will use the KMS keyId and the base64 encoded encryptedStr and return it decrypted as a plain string.
 func (c *kmsCipher) Decrypt(ctx context.Context, keyID string, encryptedStr string) (string, error) {
 	return c.Client.Decrypt(ctx, keyID, encryptedStr)
 }

--- a/cipher/package.go
+++ b/cipher/package.go
@@ -5,6 +5,11 @@ import (
 	"os"
 )
 
+// DefaultKMSCipher is the package level default implementation used by all package level methods.
+// Package level methods are provided for ease of use.
+// For testing you can replace the DefaultKMSCipher client with your own mock:
+//
+//	DefaultKMSCipher = newMockedClient()
 var DefaultKMSCipher KMSCipher = getInstance()
 
 func getInstance() *kmsCipher {
@@ -15,12 +20,12 @@ func getInstance() *kmsCipher {
 	return NewKMSCipherWithClient(client)
 }
 
-// Encrypt uses the default AWS_REGION to kms encrypt "plainStr".
+// Encrypt will use env var AWS_REGION and the KMS keyId to encrypt the plainStr and return it as a base64 encoded string.
 func Encrypt(ctx context.Context, keyId string, plainStr string) (string, error) {
 	return DefaultKMSCipher.Encrypt(ctx, keyId, plainStr)
 }
 
-// Decrypt uses the default AWS_REGION and KMS_KEY_ID to kms decrypt "encryptedStr".
+// Decrpyt will use env var AWS_REGION and the KMS keyId and the base64 encoded encryptedStr and return it decrypted as a plain string.
 func Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error) {
 	return DefaultKMSCipher.Decrypt(ctx, keyId, encryptedStr)
 }

--- a/cipher/package.go
+++ b/cipher/package.go
@@ -2,7 +2,9 @@ package cipher
 
 import (
 	"context"
+	"flag"
 	"os"
+	"strings"
 
 	"github.com/go-errors/errors"
 )
@@ -19,8 +21,15 @@ func getInstance() *kmsCipher {
 
 	region, ok := os.LookupEnv("AWS_REGION")
 	if !ok || region == "" {
-		err := errors.Errorf("missing AWS_REGION environment variable")
-		panic(err)
+		if !isTestMode() {
+			err := errors.Errorf("missing AWS_REGION environment variable")
+			panic(err)
+		}
+
+		err := os.Setenv("AWS_REGION", "dev")
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	client = newAWSKMSClient(region)
@@ -35,4 +44,18 @@ func Encrypt(ctx context.Context, keyId string, plainStr string) (string, error)
 // Decrpyt will use env var AWS_REGION and the KMS keyId and the base64 encoded encryptedStr and return it decrypted as a plain string.
 func Decrypt(ctx context.Context, keyId string, encryptedStr string) (string, error) {
 	return DefaultKMSCipher.Decrypt(ctx, keyId, encryptedStr)
+}
+
+func isTestMode() bool {
+	// https://stackoverflow.com/questions/14249217/how-do-i-know-im-running-within-go-test
+	argZero := os.Args[0]
+
+	if strings.HasSuffix(argZero, ".test") ||
+		strings.Contains(argZero, "/_test/") ||
+		strings.Contains(argZero, "__debug_bin") || // vscode debug binary
+		flag.Lookup("test.v") != nil {
+		return true
+	}
+
+	return false
 }

--- a/cipher/package.go
+++ b/cipher/package.go
@@ -3,6 +3,8 @@ package cipher
 import (
 	"context"
 	"os"
+
+	"github.com/go-errors/errors"
 )
 
 // DefaultKMSCipher is the package level default implementation used by all package level methods.
@@ -15,7 +17,12 @@ var DefaultKMSCipher KMSCipher = getInstance()
 func getInstance() *kmsCipher {
 	var client KMSCipher
 
-	region := os.Getenv("AWS_REGION")
+	region, ok := os.LookupEnv("AWS_REGION")
+	if !ok || region == "" {
+		err := errors.Errorf("missing AWS_REGION environment variable")
+		panic(err)
+	}
+
 	client = newAWSKMSClient(region)
 	return NewKMSCipherWithClient(client)
 }


### PR DESCRIPTION
Changes:
- Updated comments on all public methods
- Encrypt/Decrypt are now all consistently documented across package and instance methods
- Now panic on startup if AWS_REGION not set
- Updated CIPHER.md to reflect AWS_REGION panic