### PR TITLE
JWT public comment updates

### DIFF
--- a/jwt/JWT.md
+++ b/jwt/JWT.md
@@ -10,6 +10,7 @@ To use the package level methods `Encode` and `Decode` you MUST set these:
 - AUTH_PRIVATE_KEY = The private RSA PEM key used for Encoding a token.
 - AUTH_PRIVATE_KEY_ID = The "kid" (key_id) header to add to the token heading when Encoding.
 
+Failure to set these will result in a panic() at start up.
 
 ## Runtime Key Rotation
 

--- a/jwt/decoder.go
+++ b/jwt/decoder.go
@@ -26,6 +26,7 @@ const (
 
 type publicKey interface{} // Only ECDSA (perferred) and RSA public keys allowed
 
+// DecoderJwksRetriever defines the function signature required to retrieve JWKS json.
 type DecoderJwksRetriever func() string
 
 // JwtDecoder can decode a jwt token string.

--- a/jwt/decoder_options.go
+++ b/jwt/decoder_options.go
@@ -6,6 +6,11 @@ import (
 
 type JwtDecoderOption func(*JwtDecoder)
 
+// WithDecoderCacheExpiry sets the JwtDecoder JWKs cache expiry time.
+// defaultExpiration defaults to 60 minutes.
+// cleanupInterval defaults to every 1 minute.
+// For no expiry (not recommended for production) use:
+// defaultExpiration to NoExpiration (ie. time.Duration = -1).
 func WithDecoderCacheExpiry(defaultExpiration, cleanupInterval time.Duration) JwtDecoderOption {
 	return func(decoder *JwtDecoder) {
 		decoder.defaultExpiration = defaultExpiration

--- a/jwt/decoder_options.go
+++ b/jwt/decoder_options.go
@@ -4,6 +4,7 @@ import (
 	"time"
 )
 
+// JwtDecoderOption function signature for added JWT Decoder options.
 type JwtDecoderOption func(*JwtDecoder)
 
 // WithDecoderCacheExpiry sets the JwtDecoder JWKs cache expiry time.

--- a/jwt/encoder.go
+++ b/jwt/encoder.go
@@ -22,10 +22,11 @@ const (
 	ecdsaKey256
 )
 
-type (
-	privateKey          interface{} // Only ECDSA (perferred) and RSA public keys allowed
-	EncoderKeyRetriever func() (string, string)
-)
+// Only ECDSA (perferred) and RSA public keys allowed.
+type privateKey interface{}
+
+// EncoderKeyRetriever defines the function signature required to retrieve private PEM key.
+type EncoderKeyRetriever func() (string, string)
 
 type encoderPrivateKey struct {
 	privateSigningKey privateKey

--- a/jwt/encoder_options.go
+++ b/jwt/encoder_options.go
@@ -4,8 +4,14 @@ import (
 	"time"
 )
 
+// JwtEncoderOption function signature for added JWT Encoder options.
 type JwtEncoderOption func(*JwtEncoder)
 
+// WithEncoderCacheExpiry sets the JwtEncoder private key cache expiry time.
+// defaultExpiration defaults to 60 minutes.
+// cleanupInterval defaults to every 1 minute.
+// For no expiry (not recommended for production) use:
+// defaultExpiration to NoExpiration (ie. time.Duration = -1).
 func WithEncoderCacheExpiry(defaultExpiration, cleanupInterval time.Duration) JwtEncoderOption {
 	return func(encoder *JwtEncoder) {
 		encoder.defaultExpiration = defaultExpiration

--- a/jwt/package.go
+++ b/jwt/package.go
@@ -23,7 +23,7 @@ var (
 	// DefaultJwtEncoder used to package level methods.
 	// This can be mocked during tests if required by supporting the Encoder interface.
 	DefaultJwtEncoder Encoder = getEncoderInstance()
-	// DefaultJwtDecoder used for package leel methods.
+	// DefaultJwtDecoder used for package level methods.
 	// This can be mocked during tests if required by supporting the Decoder interface.
 	DefaultJwtDecoder Decoder = getDecoderInstance()
 )

--- a/jwt/package.go
+++ b/jwt/package.go
@@ -20,7 +20,11 @@ type Decoder interface {
 }
 
 var (
+	// DefaultJwtEncoder used to package level methods.
+	// This can be mocked during tests if required by supporting the Encoder interface.
 	DefaultJwtEncoder Encoder = getEncoderInstance()
+	// DefaultJwtDecoder used for package leel methods.
+	// This can be mocked during tests if required by supporting the Decoder interface.
 	DefaultJwtDecoder Decoder = getDecoderInstance()
 )
 


### PR DESCRIPTION
Changes:
- Updated missing or incorrect public comments
- Now panic at startup if missing AUTH_PUBLIC_JWK_KEYS, AUTH_PRIVATE_KEY, or AUTH_PRIVATE_KEY_ID
- Updated JWT.md to reflect this change