### PR TITLE
Added support for custom decoded claims

### DIFF
--- a/jwt/JWT.md
+++ b/jwt/JWT.md
@@ -177,4 +177,9 @@ func (m *mockedEncoderDecoder) Decode(tokenString string) (*jwt.StandardClaims, 
 	output, _ := args.Get(0).(*jwt.StandardClaims)
 	return output, args.Error(1)
 }
+
+func (m *mockedEncoderDecoder) DecodeWithCustomClaims(tokenString string, customClaims gojwt.Claims) error {
+	args := m.Called(tokenString, customClaims)
+	return args.Error(0)
+}
 ```

--- a/jwt/claims.go
+++ b/jwt/claims.go
@@ -18,7 +18,7 @@ type StandardClaims struct {
 	Issuer string
 	// the `sub` (Subject) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.2
 	Subject string
-	// the `sub` (Subject) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
+	// the `aud` (Audience) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.3
 	Audience []string
 	// the `exp` (Expiration Time) claim. See https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.4
 	ExpiresAt time.Time // default on Encode is +1 hour from now

--- a/jwt/jwt_example_test.go
+++ b/jwt/jwt_example_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/cultureamp/ca-go/jwt"
+	gojwt "github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/mock"
 )
 
@@ -154,4 +155,9 @@ func (m *mockedEncoderDecoder) Decode(tokenString string) (*jwt.StandardClaims, 
 	args := m.Called(tokenString)
 	output, _ := args.Get(0).(*jwt.StandardClaims)
 	return output, args.Error(1)
+}
+
+func (m *mockedEncoderDecoder) DecodeWithCustomClaims(tokenString string, customClaims gojwt.Claims) error {
+	args := m.Called(tokenString, customClaims)
+	return args.Error(0)
 }

--- a/jwt/package.go
+++ b/jwt/package.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-errors/errors"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 // Encoder interface allows for mocking of the Encoder.
@@ -17,6 +18,7 @@ type Encoder interface {
 // Decoder interface allows for mocking of the Decoder.
 type Decoder interface {
 	Decode(tokenString string) (*StandardClaims, error)
+	DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error
 }
 
 var (
@@ -95,6 +97,11 @@ func privateKeyFromEnvVarRetriever() (string, string) {
 // Decode a jwt token string and return the Standard Culture Amp Claims.
 func Decode(tokenString string) (*StandardClaims, error) {
 	return DefaultJwtDecoder.Decode(tokenString)
+}
+
+// DecodeWithCustomClaims takes a jwt token string and populate the customClaims.
+func DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error {
+	return DefaultJwtDecoder.DecodeWithCustomClaims(tokenString, customClaims)
 }
 
 // Encode the Standard Culture Amp Claims in a jwt token string.


### PR DESCRIPTION
Purpose: To be able to pass in custom claims to the JWT decoder

Changes:
- Added DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error 
- Updated JWT.md
