### PR TITLE
JWT: no longer panic at start up for package level  default encoder/decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ These packages are stable and there use is actively encouraged.
 
 - `cipher`: easy access to kms Encrypt/Decrpyt. See [cipher](cipher/CIPHER.md) for further details.
 - `env`: easy access to common environment settings. See [env](env/ENV.md) for further details.
-- `jwt`: encode and decode the Culture Amp authentication payload. See [jwt](jwt/JWT.md) for further details.
-- `kafka`: simplified implementation of kafka consumer and consumer group to make kafka in go projects easier. 
+- `jwt`: encode and decode the Culture Amp authentication payload. See [jwt](jwt/README.md) for further details.
+- `kafka`: simplified implementation of kafka consumer and consumer group to make kafka in go projects easier.
 See [consumer](kafka/consumer/CONSUMER.MD) for further details.
 - `launchdarkly`: eases the implementation and usage of LaunchDarkly for feature flags, encapsulating usage patterns in
 Culture Amp.See [launchdarkly](launchdarkly/LAUNCHDARKLY.md) for further details.
-- `log`: easy and simple logging that confirms to the logging engineer standard. 
+- `log`: easy and simple logging that confirms to the logging engineer standard.
 See [logger](log/LOGGER.md) for further details.
 - `ref`: simple methods to create pointers from literals
 - `request`: encapsulates the availability of request information on the request context.

--- a/jwt/package.go
+++ b/jwt/package.go
@@ -25,94 +25,110 @@ type Decoder interface {
 var (
 	// DefaultJwtEncoder used to package level methods.
 	// This can be mocked during tests if required by supporting the Encoder interface.
-	DefaultJwtEncoder Encoder = getEncoderInstance()
+	DefaultJwtEncoder Encoder = nil
 	// DefaultJwtDecoder used for package level methods.
 	// This can be mocked during tests if required by supporting the Decoder interface.
-	DefaultJwtDecoder Decoder = getDecoderInstance()
+	DefaultJwtDecoder Decoder = nil
 )
-
-func getDecoderInstance() *JwtDecoder {
-	decoder, err := NewJwtDecoder(jwksFromEnvVarRetriever)
-	if err != nil {
-		err := errors.Errorf("error loading default jwk decoder, maybe missing env vars: err='%w'\n", err)
-		panic(err)
-	}
-
-	return decoder
-}
-
-func jwksFromEnvVarRetriever() string {
-	jwkKeys, ok := os.LookupEnv("AUTH_PUBLIC_JWK_KEYS")
-	if !ok || jwkKeys == "" {
-		if !isTestMode() {
-			err := errors.Errorf("missing AUTH_PUBLIC_JWK_KEYS environment variable - this should be set to a JWKS json string.")
-			panic(err)
-		}
-		// If we are running inside a test, the make sure the DefaultJwtDecoder package level
-		// instance doesn't panic with missing values.
-		// test key only, not the production keys
-		b, _ := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
-		jwkKeys = string(b)
-	}
-
-	return jwkKeys
-}
-
-func getEncoderInstance() *JwtEncoder {
-	encoder, err := NewJwtEncoder(privateKeyFromEnvVarRetriever)
-	if err != nil {
-		err := errors.Errorf("error loading jwk encoder, maybe missing env vars: err='%w'\n", err)
-		panic(err)
-	}
-
-	return encoder
-}
-
-func privateKeyFromEnvVarRetriever() (string, string) {
-	privKey, ok := os.LookupEnv("AUTH_PRIVATE_KEY")
-	if !ok || privKey == "" {
-		if !isTestMode() {
-			err := errors.Errorf("missing AUTH_PRIVATE_KEY environment variable - this should be set to a private PEM key for this service.")
-			panic(err)
-		}
-		// If we are running inside a test, the make sure the DefaultJwtEncoder package level
-		// instance doesn't panic with missing values.
-		// test key only, not the production key
-		b, _ := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
-		privKey = string(b)
-	}
-
-	keyId, ok := os.LookupEnv("AUTH_PRIVATE_KEY_ID")
-	if !ok || keyId == "" {
-		if !isTestMode() {
-			err := errors.Errorf("missing AUTH_PRIVATE_KEY_ID environment variable - this should be set key_id for this service.")
-			panic(err)
-		}
-		// test key_id to web-gateway only, not the production key_id
-		keyId = webGatewayKid
-	}
-
-	return privKey, keyId
-}
 
 // Decode a jwt token string and return the Standard Culture Amp Claims.
 func Decode(tokenString string) (*StandardClaims, error) {
+	err := mustHaveDefaultJwtDecoder()
+	if err != nil {
+		return nil, err
+	}
 	return DefaultJwtDecoder.Decode(tokenString)
 }
 
 // DecodeWithCustomClaims takes a jwt token string and populate the customClaims.
 func DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error {
+	err := mustHaveDefaultJwtDecoder()
+	if err != nil {
+		return err
+	}
 	return DefaultJwtDecoder.DecodeWithCustomClaims(tokenString, customClaims)
 }
 
 // Encode the Standard Culture Amp Claims in a jwt token string.
 func Encode(claims *StandardClaims) (string, error) {
+	err := mustHaveDefaultJwtEncoder()
+	if err != nil {
+		return "", err
+	}
 	return DefaultJwtEncoder.Encode(claims)
 }
 
 // EncodeWithCustomClaims encodes the Custom Claims in a jwt token string.
 func EncodeWithCustomClaims(customClaims jwt.Claims) (string, error) {
+	err := mustHaveDefaultJwtEncoder()
+	if err != nil {
+		return "", err
+	}
 	return DefaultJwtEncoder.EncodeWithCustomClaims(customClaims)
+}
+
+func mustHaveDefaultJwtDecoder() error {
+	if DefaultJwtDecoder != nil {
+		return nil // its set so we are good to go
+	}
+
+	decoder, err := NewJwtDecoder(jwksFromEnvVarRetriever)
+	if err != nil {
+		return errors.Errorf("error loading default jwk decoder, maybe missing env vars: err='%w'\n", err)
+	}
+
+	DefaultJwtDecoder = decoder
+	return nil
+}
+
+func jwksFromEnvVarRetriever() string {
+	jwkKeys, ok := os.LookupEnv("AUTH_PUBLIC_JWK_KEYS")
+	if !ok || jwkKeys == "" {
+		if isTestMode() {
+			// If we are running inside a test, the make sure the DefaultJwtDecoder package level
+			// instance loads these test keys be default.
+			b, _ := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
+			jwkKeys = string(b)
+		}
+	}
+
+	return jwkKeys
+}
+
+func mustHaveDefaultJwtEncoder() error {
+	if DefaultJwtEncoder != nil {
+		return nil // its set so we are good to go
+	}
+
+	encoder, err := NewJwtEncoder(privateKeyFromEnvVarRetriever)
+	if err != nil {
+		return errors.Errorf("error loading jwk encoder, maybe missing env vars: err='%w'\n", err)
+	}
+
+	DefaultJwtEncoder = encoder
+	return nil
+}
+
+func privateKeyFromEnvVarRetriever() (string, string) {
+	privKey, ok := os.LookupEnv("AUTH_PRIVATE_KEY")
+	if !ok || privKey == "" {
+		if isTestMode() {
+			// If we are running inside a test, the make sure the DefaultJwtEncoder package level
+			// instance loads this test key by default.
+			b, _ := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
+			privKey = string(b)
+		}
+	}
+
+	keyId, ok := os.LookupEnv("AUTH_PRIVATE_KEY_ID")
+	if !ok || keyId == "" {
+		if isTestMode() {
+			// test key_id to web-gateway only, not the production key_id
+			keyId = webGatewayKid
+		}
+	}
+
+	return privKey, keyId
 }
 
 func isTestMode() bool {

--- a/jwt/package_test.go
+++ b/jwt/package_test.go
@@ -165,8 +165,8 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 			t.Setenv("AUTH_PRIVATE_KEY", privateKeys)
 
 			// Encode this claim
-			encoder := getEncoderInstance()
-			token, err := encoder.Encode(claims)
+			DefaultJwtEncoder = nil // force re-create
+			token, err := Encode(claims)
 			if tC.expectedEncoderErrMsg == "" {
 				assert.Nil(t, err)
 			} else {
@@ -177,8 +177,8 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 			t.Setenv("AUTH_PUBLIC_JWK_KEYS", "")
 
 			// Decode it back again
-			decoder := getDecoderInstance()
-			sc, err := decoder.Decode(token)
+			DefaultJwtDecoder = nil // force re-create
+			sc, err := Decode(token)
 			if tC.expectedDecoderErrMsg == "" {
 				assert.Nil(t, err)
 				// check it matches
@@ -194,4 +194,7 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 			}
 		})
 	}
+
+	DefaultJwtEncoder = nil // force re-create for next test
+	DefaultJwtDecoder = nil // force re-create for next test
 }

--- a/jwt/package_test.go
+++ b/jwt/package_test.go
@@ -19,7 +19,14 @@ func TestPackageEncodeDecode(t *testing.T) {
 		Audience:        []string{"decoder-name"},
 	}
 
+	defer func() {
+		// Force re-create of defaults when test finished
+		DefaultJwtEncoder = nil
+		DefaultJwtDecoder = nil
+	}()
+
 	// Encode this claim
+	setupEncodeDecodeForTests()
 	token, err := Encode(claims)
 	assert.Nil(t, err)
 
@@ -75,6 +82,12 @@ func TestPackageEncodeDecodeNotBeforeExpiryChecks(t *testing.T) {
 		NotBefore:       notBefore,
 	}
 
+	defer func() {
+		// Force re-create of defaults when test finished
+		DefaultJwtEncoder = nil
+		DefaultJwtDecoder = nil
+	}()
+
 	testCases := []struct {
 		desc                  string
 		claims                *StandardClaims
@@ -99,6 +112,7 @@ func TestPackageEncodeDecodeNotBeforeExpiryChecks(t *testing.T) {
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
 			// Encode this claim
+			setupEncodeDecodeForTests()
 			token, err := Encode(tC.claims)
 			assert.Nil(t, err)
 
@@ -131,6 +145,12 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 		Audience:        []string{"decoder-name"},
 	}
 
+	defer func() {
+		// Force re-create of defaults when test finished
+		DefaultJwtEncoder = nil
+		DefaultJwtDecoder = nil
+	}()
+
 	testCases := []struct {
 		desc                  string
 		encodedKeyId          string
@@ -139,14 +159,14 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 		expectedDecoderErrMsg string
 	}{
 		{
-			desc:                  "Success 1: missing env vars defaults to test values",
+			desc:                  "Error 1: missing env vars",
 			encodedKeyId:          "",
 			privateKey:            "",
-			expectedEncoderErrMsg: "",
-			expectedDecoderErrMsg: "",
+			expectedEncoderErrMsg: "error loading jwk encoder, maybe missing env vars",
+			expectedDecoderErrMsg: "token is malformed: token contains an invalid number of segments",
 		},
 		{
-			desc:                  "Error 1: missing decoder kid",
+			desc:                  "Error 2: missing decoder kid",
 			encodedKeyId:          "missing-kid",
 			privateKey:            testECDSA521PrivateKey,
 			expectedEncoderErrMsg: "",
@@ -174,10 +194,7 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 				assert.ErrorContains(t, err, tC.expectedEncoderErrMsg)
 			}
 
-			t.Setenv("AUTH_PUBLIC_JWK_KEYS", "")
-
 			// Decode it back again
-			DefaultJwtDecoder = nil // force re-create
 			sc, err := Decode(token)
 			if tC.expectedDecoderErrMsg == "" {
 				assert.Nil(t, err)
@@ -194,7 +211,17 @@ func TestPackageEncodeDecodeWithDifferentEnvVars(t *testing.T) {
 			}
 		})
 	}
+}
 
-	DefaultJwtEncoder = nil // force re-create for next test
-	DefaultJwtDecoder = nil // force re-create for next test
+func setupEncodeDecodeForTests() {
+	DefaultJwtEncoder = nil
+	wb, _ := os.ReadFile(filepath.Clean("./testKeys/jwt-rsa256-test-webgateway.key"))
+	privKey := string(wb)
+	os.Setenv("AUTH_PRIVATE_KEY", privKey)
+	os.Setenv("AUTH_PRIVATE_KEY_ID", webGatewayKid)
+
+	DefaultJwtDecoder = nil
+	db, _ := os.ReadFile(filepath.Clean("./testKeys/development.jwks"))
+	jwkKeys := string(db)
+	os.Setenv("AUTH_PUBLIC_JWK_KEYS", jwkKeys)
 }


### PR DESCRIPTION
Purpose: Stop panic at startup for missing env-vars

Changes:
- Removed panics, throw errors when using instead of at startup
- Removed isTestMode
- Package level tests now load test keys (rather than rely on startup to do it)
- Renamed JWT.md to README.md and updated with the latest updates
