### PR TITLE
Log Package: return error on Details and Send instead of panic

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           version: "latest"
           args: --verbose --timeout=5m
-          skip-pkg-cache: true
+          skip-cache: false
 
       - name: GoVet
         run: go vet ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -159,7 +159,7 @@ linters-settings:
           - github.com/rs/zerolog
           - github.com/stoewer/go-strcase
           - github.com/IBM/sarama
-          # not sure about these below
+          # these will be retired soon
           - github.com/cenkalti/backoff
           - github.com/xdg-go/scram
           - github.com/segmentio
@@ -171,8 +171,6 @@ linters-settings:
             desc: Should be replaced by github.com/go-errors/errors package errors.Errorf("msg %v", err)
           - pkg: "github.com/hashicorp"
             desc: not allowed
-          #- pkg: "github.com/segmentio"
-          #  desc: not allowed, instead use github.com/IBM/sarama for Kafka
           - pkg: "github.com/kelseyhightower/envconfig"
             desc: not allowed, instead use github.com/caarlos0/env/v11 for environment to struct
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -162,6 +162,7 @@ linters-settings:
           # not sure about these below
           - github.com/cenkalti/backoff
           - github.com/xdg-go/scram
+          - github.com/segmentio
         # Packages that are not allowed where the value is a suggestion.
         deny:
           - pkg: "github.com/sirupsen/logrus"
@@ -170,8 +171,8 @@ linters-settings:
             desc: Should be replaced by github.com/go-errors/errors package errors.Errorf("msg %v", err)
           - pkg: "github.com/hashicorp"
             desc: not allowed
-          - pkg: "github.com/segmentio"
-            desc: not allowed, instead use github.com/IBM/sarama for Kafka
+          #- pkg: "github.com/segmentio"
+          #  desc: not allowed, instead use github.com/IBM/sarama for Kafka
           - pkg: "github.com/kelseyhightower/envconfig"
             desc: not allowed, instead use github.com/caarlos0/env/v11 for environment to struct
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -153,17 +153,14 @@ linters-settings:
           - github.com/google
           - github.com/golang-jwt
           - github.com/go-errors
-          - github.com/hashicorp
           - github.com/launchdarkly
           - github.com/lestrrat-go
           - github.com/patrickmn/go-cache
           - github.com/rs/zerolog
-          - github.com/segmentio
           - github.com/stoewer/go-strcase
+          - github.com/IBM/sarama
           # not sure about these below
           - github.com/cenkalti/backoff
-          - github.com/IBM/sarama
-          - github.com/kelseyhightower/envconfig
           - github.com/xdg-go/scram
         # Packages that are not allowed where the value is a suggestion.
         deny:
@@ -171,6 +168,13 @@ linters-settings:
             desc: not allowed
           - pkg: "github.com/pkg/errors"
             desc: Should be replaced by github.com/go-errors/errors package errors.Errorf("msg %v", err)
+          - pkg: "github.com/hashicorp"
+            desc: not allowed
+          - pkg: "github.com/segmentio"
+            desc: not allowed, instead use github.com/IBM/sarama for Kafka
+          - pkg: "github.com/kelseyhightower/envconfig"
+            desc: not allowed, instead use github.com/caarlos0/env/v11 for environment to struct
+
 
   tagliatelle:
     # Check the struct tag name case.

--- a/launchdarkly/client.go
+++ b/launchdarkly/client.go
@@ -59,7 +59,7 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 		config, err := configFromEnvironment()
 		if err != nil {
 			err = fmt.Errorf("could not configure from environment variable: %w", err)
-			log.Error("flags_startup_error", err).Send()
+			log.Error("flags_startup_error", err).Send() //nolint:errcheck
 			return nil, err
 		}
 		parsedConfig = config

--- a/launchdarkly/client.go
+++ b/launchdarkly/client.go
@@ -59,7 +59,8 @@ func NewClient(opts ...ConfigOption) (*Client, error) {
 		config, err := configFromEnvironment()
 		if err != nil {
 			err = fmt.Errorf("could not configure from environment variable: %w", err)
-			log.Error("flags_startup_error", err).Send() //nolint:errcheck
+			//nolint:errcheck
+			log.Error("flags_startup_error", err).Send() //#nosec G104
 			return nil, err
 		}
 		parsedConfig = config

--- a/log/config.go
+++ b/log/config.go
@@ -160,6 +160,8 @@ func (c *Config) formatTimestamp(i interface{}) string {
 	return timeString
 }
 
+// isValid returns nil if all the mandatory env_vars are correctly set,
+// otherwise an error indicating the issue.
 func (c *Config) isValid() error {
 	if c.AppName == "" {
 		return errors.Errorf("config.AppName is empty - missing APP or APP_NAME environment variable?")

--- a/log/config.go
+++ b/log/config.go
@@ -176,14 +176,6 @@ func (c *Config) shouldProcess() error {
 	return nil
 }
 
-func (c *Config) mustProcess() {
-	err := c.shouldProcess()
-	if err != nil {
-		// panics if mandatory env vars are not set
-		panic(err)
-	}
-}
-
 // GetBool gets the environment variable for 'key' if present, otherwise returns 'fallback'.
 func getEnvBool(key string, defaultValue bool) bool {
 	value, ok := os.LookupEnv(key)

--- a/log/config.go
+++ b/log/config.go
@@ -160,7 +160,7 @@ func (c *Config) formatTimestamp(i interface{}) string {
 	return timeString
 }
 
-func (c *Config) shouldProcess() error {
+func (c *Config) isValid() error {
 	if c.AppName == "" {
 		return errors.Errorf("config.AppName is empty - missing APP or APP_NAME environment variable?")
 	}

--- a/log/config_test.go
+++ b/log/config_test.go
@@ -26,6 +26,7 @@ func TestNewLoggerConfigWithNoEnvVarSet(t *testing.T) {
 	assert.Equal(t, "local", config.Farm)
 	assert.Equal(t, "", config.Product)
 	assert.Equal(t, false, config.Quiet)
+	assert.ErrorContains(t, config.isValid(), "config.AppName is empty")
 }
 
 func TestNewLoggerConfigWithEnvVarSet(t *testing.T) {
@@ -48,4 +49,5 @@ func TestNewLoggerConfigWithEnvVarSet(t *testing.T) {
 	assert.Equal(t, "production", config.Farm)
 	assert.Equal(t, "performance", config.Product)
 	assert.Equal(t, true, config.Quiet)
+	assert.Nil(t, config.isValid())
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -62,44 +62,44 @@ func (l *standardLogger) Enabled(logLevel string) bool {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Debug(event string) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	err := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Debug().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le)
+	return newLoggerProperty(le, err)
 }
 
 // Info starts a new message with info level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Info(event string) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	err := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Info().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le)
+	return newLoggerProperty(le, err)
 }
 
 // Warn starts a new message with warn level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Warn(event string) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	err := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Warn().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le)
+	return newLoggerProperty(le, err)
 }
 
 // Error starts a new message with error level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Error(event string, err error) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	sperr := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Error()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le).WithSystemTracing()
+	return newLoggerProperty(le, sperr).WithSystemTracing()
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function
@@ -107,14 +107,14 @@ func (l *standardLogger) Error(event string, err error) *Property {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Fatal(event string, err error) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	sperr := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Fatal()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le).WithSystemTracing()
+	return newLoggerProperty(le, sperr).WithSystemTracing()
 }
 
 // Panic starts a new message with panic level. The panic() function
@@ -122,12 +122,12 @@ func (l *standardLogger) Fatal(event string, err error) *Property {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Panic(event string, err error) *Property {
-	l.config.mustProcess() // make sure mandatory config values are set
+	sperr := l.config.shouldProcess() // make sure mandatory config values are set
 
 	le := l.impl.Panic()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le).WithSystemTracing()
+	return newLoggerProperty(le, sperr).WithSystemTracing()
 }

--- a/log/logger.go
+++ b/log/logger.go
@@ -62,44 +62,36 @@ func (l *standardLogger) Enabled(logLevel string) bool {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Debug(event string) *Property {
-	err := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Debug().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, err)
+	return newLoggerProperty(le, l.config)
 }
 
 // Info starts a new message with info level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Info(event string) *Property {
-	err := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Info().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, err)
+	return newLoggerProperty(le, l.config)
 }
 
 // Warn starts a new message with warn level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Warn(event string) *Property {
-	err := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Warn().Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, err)
+	return newLoggerProperty(le, l.config)
 }
 
 // Error starts a new message with error level.
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Error(event string, err error) *Property {
-	sperr := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Error()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, sperr).WithSystemTracing()
+	return newLoggerProperty(le, l.config).WithSystemTracing()
 }
 
 // Fatal starts a new message with fatal level. The os.Exit(1) function
@@ -107,14 +99,12 @@ func (l *standardLogger) Error(event string, err error) *Property {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Fatal(event string, err error) *Property {
-	sperr := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Fatal()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, sperr).WithSystemTracing()
+	return newLoggerProperty(le, l.config).WithSystemTracing()
 }
 
 // Panic starts a new message with panic level. The panic() function
@@ -122,12 +112,10 @@ func (l *standardLogger) Fatal(event string, err error) *Property {
 //
 // You must call Msg or Send on the returned event in order to send the event to the output.
 func (l *standardLogger) Panic(event string, err error) *Property {
-	sperr := l.config.shouldProcess() // make sure mandatory config values are set
-
 	le := l.impl.Panic()
 	le.Dict("error", zerolog.Dict().
 		Stack().
 		Err(err),
 	).Str("event", strcase.SnakeCase(event))
-	return newLoggerProperty(le, sperr).WithSystemTracing()
+	return newLoggerProperty(le, l.config).WithSystemTracing()
 }

--- a/log/properties.go
+++ b/log/properties.go
@@ -6,11 +6,15 @@ import (
 
 // Property contains an element of the log, usually a key-value pair.
 type Property struct {
-	impl *zerolog.Event
+	impl      *zerolog.Event
+	configErr error
 }
 
-func newLoggerProperty(impl *zerolog.Event) *Property {
-	return &Property{impl: impl}
+func newLoggerProperty(impl *zerolog.Event, configError error) *Property {
+	return &Property{
+		impl:      impl,
+		configErr: configError,
+	}
 }
 
 // Properties adds an entire sub-document of type Property to the log.
@@ -24,8 +28,9 @@ func (lf *Property) Properties(fields *Field) *Property {
 //
 // NOTICE: once this method is called, the *Property should be disposed.
 // Calling Details twice can have unexpected result.
-func (lf *Property) Details(details string) {
+func (lf *Property) Details(details string) error {
 	lf.impl.Msg(details)
+	return lf.configErr
 }
 
 // Detailsf adds the property 'details' with the format and args to the log.
@@ -34,16 +39,18 @@ func (lf *Property) Details(details string) {
 //
 // NOTICE: once this method is called, the *Property should be disposed.
 // Calling Detailsf twice can have unexpected result.
-func (lf *Property) Detailsf(format string, v ...interface{}) {
+func (lf *Property) Detailsf(format string, v ...interface{}) error {
 	lf.impl.Msgf(format, v...)
+	return lf.configErr
 }
 
 // Send terminates the log and signals that it is now complete and can be
 // sent to the output.
 //
 // NOTICE: once this method is called, the *Property should be disposed.
-func (lf *Property) Send() {
+func (lf *Property) Send() error {
 	lf.impl.Send()
+	return lf.configErr
 }
 
 func (lf *Property) doc(key string, fields *Field) *Property {

--- a/log/properties.go
+++ b/log/properties.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"github.com/go-errors/errors"
 	"github.com/rs/zerolog"
 )
 
@@ -10,10 +11,15 @@ type Property struct {
 	configErr error
 }
 
-func newLoggerProperty(impl *zerolog.Event, configError error) *Property {
+func newLoggerProperty(impl *zerolog.Event, config *Config) *Property {
+	var err error = errors.Errorf("invalid logger config")
+	if config != nil {
+		err = config.isValid()
+	}
+
 	return &Property{
 		impl:      impl,
-		configErr: configError,
+		configErr: err,
 	}
 }
 

--- a/log/properties.go
+++ b/log/properties.go
@@ -12,7 +12,8 @@ type Property struct {
 }
 
 func newLoggerProperty(impl *zerolog.Event, config *Config) *Property {
-	var err error = errors.Errorf("invalid logger config")
+	// Default is to assume there is no config (ie. from mocks, tests, etc)
+	var err error = errors.Errorf("missing logger config")
 	if config != nil {
 		err = config.isValid()
 	}
@@ -30,10 +31,11 @@ func (lf *Property) Properties(fields *Field) *Property {
 
 // Details adds the property 'details' with the val as a string to the log.
 // This is a terminating Property that signals that the log statement is complete
-// and can now be sent to the output.
+// and can now be sent to the output. It returns nil on success, or an error if
+// there was a problem.
 //
 // NOTICE: once this method is called, the *Property should be disposed.
-// Calling Details twice can have unexpected result.
+// Calling Details twice can have unexpected results.
 func (lf *Property) Details(details string) error {
 	lf.impl.Msg(details)
 	return lf.configErr
@@ -41,19 +43,22 @@ func (lf *Property) Details(details string) error {
 
 // Detailsf adds the property 'details' with the format and args to the log.
 // This is a terminating Property that signals that the log statement is complete
-// and can now be sent to the output.
+// and can now be sent to the output.It returns nil on success, or an error if
+// there was a problem.
 //
 // NOTICE: once this method is called, the *Property should be disposed.
-// Calling Detailsf twice can have unexpected result.
+// Calling Detailsf twice can have unexpected results.
 func (lf *Property) Detailsf(format string, v ...interface{}) error {
 	lf.impl.Msgf(format, v...)
 	return lf.configErr
 }
 
 // Send terminates the log and signals that it is now complete and can be
-// sent to the output.
+// sent to the output. It returns nil on success, or an error if
+// there was a problem.
 //
 // NOTICE: once this method is called, the *Property should be disposed.
+// Calling Send twice can have unexpected results.
 func (lf *Property) Send() error {
 	lf.impl.Send()
 	return lf.configErr

--- a/sentry/examples_test.go
+++ b/sentry/examples_test.go
@@ -40,7 +40,7 @@ func Example_lambda() {
 
 	ctx := context.Background()
 
-	// in a real application, use something like "github.com/kelseyhightower/envconfig"
+	// in a real application, use something like "github.com/caarlos0/env/v11"
 	settings := getSettings()
 
 	// configure error reporting settings


### PR DESCRIPTION
Purpose: Stop panics (very rude) and instead return errors so that clients can handle if they wish.

Changes:
- Send, Details and Detailsf all return error
- Removed mustProcess() and the panic
- Updated comments
- Fixed golint warning about unknown "skip-pkg-cache" setting