### PR TITLE
Log Package: time.durations now use ISO8601 format as per logging std

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -159,6 +159,7 @@ linters-settings:
           - github.com/patrickmn/go-cache
           - github.com/rs/zerolog
           - github.com/segmentio
+          - github.com/sosodev/duration
           - github.com/stoewer/go-strcase
           # not sure about these below
           - github.com/cenkalti/backoff

--- a/go.mod
+++ b/go.mod
@@ -101,6 +101,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/secure-systems-lab/go-securesystemslib v0.7.0 // indirect
+	github.com/sosodev/duration v1.3.0
 	github.com/stoewer/go-strcase v1.3.0
 	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/tinylib/msgp v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -233,6 +233,8 @@ github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr
 github.com/segmentio/kafka-go v0.4.47 h1:IqziR4pA3vrZq7YdRxaT3w1/5fvIH5qpCwstUanQQB0=
 github.com/segmentio/kafka-go v0.4.47/go.mod h1:HjF6XbOKh0Pjlkr5GVZxt6CsjjwnmhVOfURM5KMd8qg=
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
+github.com/sosodev/duration v1.3.0 h1:g3E6mto+hFdA2uZXeNDYff8LYeg7v5D4YKP/Ng/NUkE=
+github.com/sosodev/duration v1.3.0/go.mod h1:RQIBBX0+fMLc/D9+Jb/fwvVmo0eZvDDEERAikUR6SDg=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=

--- a/log/fields.go
+++ b/log/fields.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
+	iso8601 "github.com/sosodev/duration"
 )
 
 // Field contains an element of the log, usually a key-value pair.
@@ -84,7 +85,10 @@ func (lf *Field) Bytes(key string, val []byte) *Field {
 
 // Duration adds the property key with val as an time.Duration to the log.
 func (lf *Field) Duration(key string, d time.Duration) *Field {
-	lf.impl = lf.impl.Dur(key, d)
+	// Logging Std https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3114598406/Logging+Standard#Custom-fields
+	// time durations use ISO8601 Duration format.
+	s := iso8601.Format(d)
+	lf.impl = lf.impl.Str(key, s)
 	return lf
 }
 

--- a/log/properties_test.go
+++ b/log/properties_test.go
@@ -51,7 +51,7 @@ func ExampleLogger_Debug() {
 		Detailsf("logging should contain all types: %s", "ok")
 
 	// Output:
-	// 2020-11-14T11:30:32Z DBG event="logging should contain all types: ok" app=logger-test app_version=1.0.0 aws_account_id=development aws_region=def event=debug_with_all_field_types farm=local product=cago properties={"bool":true,"bytes":"some bytes","dur":42000,"float32":32.32,"float64":64.64,"func":"val","int":1,"int64":123,"ipaddr":"255.255.255.255","str":"value","time":"2023-11-14T11:30:32Z","uint":234,"uint64":123,"uuid":"e5fa7acf-1846-41b4-a2ee-80ecd86fb060"}
+	// 2020-11-14T11:30:32Z DBG event="logging should contain all types: ok" app=logger-test app_version=1.0.0 aws_account_id=development aws_region=def event=debug_with_all_field_types farm=local product=cago properties={"bool":true,"bytes":"some bytes","dur":"PT42S","float32":32.32,"float64":64.64,"func":"val","int":1,"int64":123,"ipaddr":"255.255.255.255","str":"value","time":"2023-11-14T11:30:32Z","uint":234,"uint64":123,"uuid":"e5fa7acf-1846-41b4-a2ee-80ecd86fb060"}
 }
 
 func getExampleLoggerConfig(sev string) *Config {


### PR DESCRIPTION
Purpose: 
- Compliance with the Logging Standard
-  https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3114598406/Logging+Standard#Custom-fields

Changes:
- Added reference to github.com/sosodev/duration to support ISO8601 parsing and formatting
- Changed fields.Duration to covert time.duration to ISO8601 Duration string
