### PR TITLE
Upgraded Go to 1.22.3 to close CVE-2024-24787 and CVE-2024-24788

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: 1.22
-  GOTOOLCHAIN: go1.22.2
+  GOTOOLCHAIN: go1.22.3
 
 jobs:
   go-setup:
@@ -129,7 +129,7 @@ jobs:
           hide_complexity: true
           indicators: true
           output: both
-          thresholds: '60 80'
+          thresholds: "60 80"
 
       - name: Add Coverage PR Comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.2
+golang 1.22.3

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ These packages are stable and there use is actively encouraged.
 - `cipher`: easy access to kms Encrypt/Decrpyt. See [cipher](cipher/README.md) for further details.
 - `env`: easy access to common environment settings. See [env](env/README.md) for further details.
 - `jwt`: encode and decode the Culture Amp authentication payload. See [jwt](jwt/README.md) for further details.
-- `kafka`: simplified implementation of kafka consumer and consumer group to make kafka in go projects easier.
-See [consumer](kafka/consumer/CONSUMER.MD) for further details.
 - `launchdarkly`: eases the implementation and usage of LaunchDarkly for feature flags, encapsulating usage patterns in
 Culture Amp.See [launchdarkly](launchdarkly/LAUNCHDARKLY.md) for further details.
 - `log`: easy and simple logging that confirms to the logging engineer standard.
@@ -31,6 +29,11 @@ See [secrets](secrets/README.md) for further details.
 - `sentry`: eases the implementation and usage of Sentry for error reporting.
 See [sentry](sentry/SENTRY.md) for further details.
 
+### Deprecating packages
+
+These packages are going to be changed in the near future.
+
+- `kafka`: simplified implementation of kafka consumer and consumer group using segment-io to make kafka in go projects easier. Future change is to move to Sarama. See [consumer](kafka/consumer/CONSUMER.MD) for further details.
 
 ## Contributing
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cultureamp/ca-go
 
-go 1.22.2
+go 1.22.3
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION
Purpose: Close out security issues CVE-2024-24787 and CVE-2024-24788 in Go 1.22.2 

Changes:
- Updated go.mod, tool version and GH pipeline to 1.22.3