### PR TITLE
Package JWT: allow clients to optionally enforce matching of aud, iss and sub claims

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -183,6 +183,10 @@ issues:
         - lll
         - tagliatelle
 
+    - path: jwt/decoder.go
+      linters:
+        - ireturn
+
     - path: launchdarkly/*
       linters:
         - err113

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -105,7 +105,7 @@ type Claims interface {
 ### Enforcing Audience, Subject and Issuer
 
 When Decoding you should enforce that the jwt matches the expect Audience (`aud` claim), Subject (`sub` claim) and Issuer (`iss` claim).
-To do this you can pass option `MustMatch` to `Decode` and `DecodeWithCustomClaims` methods:
+To do this you can pass `MustMatch<Type>` to the `Decode` and `DecodeWithCustomClaims` methods:
 
 - func MustMatchAudience(aud string)
 - func MustMatchIssuer(iss string)

--- a/jwt/decoder.go
+++ b/jwt/decoder.go
@@ -84,7 +84,7 @@ func (d *JwtDecoder) DecodeWithCustomClaims(tokenString string, customClaims jwt
 		func(token *jwt.Token) (interface{}, error) {
 			return d.useCorrectPublicKey(token)
 		},
-		d.parsingOptions(options...)...,
+		d.enforceParsingOptions(options...)...,
 	)
 	if err != nil || !token.Valid {
 		return err
@@ -93,7 +93,7 @@ func (d *JwtDecoder) DecodeWithCustomClaims(tokenString string, customClaims jwt
 	return nil
 }
 
-func (d *JwtDecoder) parsingOptions(options ...DecoderParserOption) []jwt.ParserOption {
+func (d *JwtDecoder) enforceParsingOptions(options ...DecoderParserOption) []jwt.ParserOption {
 	// Eng Std: https://cultureamp.atlassian.net/wiki/spaces/TV/pages/3253240053/JWT+Authentication
 	var opts []jwt.ParserOption
 

--- a/jwt/decoder.go
+++ b/jwt/decoder.go
@@ -102,17 +102,19 @@ func (d *JwtDecoder) parsingOptions(options ...DecoderParserOption) []jwt.Parser
 	opts = append(opts,
 		jwt.WithValidMethods(validAlgs),      // only keys with these "alg's" will be considered
 		jwt.WithLeeway(defaultDecoderLeeway), // as per the JWT eng std: clock skew set to 10 seconds
+
 		// Exp
 		// Expiry claim is currently MANDATORY, but until all producing services are reliably setting the Expiry claim,
 		// we MAY still accept verified JWTs with no Expiry claim.
 		// jwt.WithExpirationRequired(),
+
 		// Nbf
-		// NotBefore claim is currently MANDATORY, but until all producing services are reliably settings the NotBefore claim,
-		// we MAY still accept verificed JWT's with no NotBefore claim.
+		// If the NotBefore claim is set it will automatically be enforced.
+		// Note: There is no parsing option for this.
 	)
 
+	// Loop through any client provided parsing options and apply them
 	parserOptions := newDecoderParser()
-	// Loop through our parsing options and apply them
 	for _, option := range options {
 		option(parserOptions)
 	}

--- a/jwt/decoder.go
+++ b/jwt/decoder.go
@@ -134,7 +134,7 @@ func (d *JwtDecoder) parsingOptions(options ...DecoderParserOption) []jwt.Parser
 	return opts
 }
 
-func (d *JwtDecoder) useCorrectPublicKey(token *jwt.Token) (publicKey, error) { //nolint:ireturn
+func (d *JwtDecoder) useCorrectPublicKey(token *jwt.Token) (publicKey, error) {
 	if token == nil {
 		return nil, errors.Errorf("failed to decode: missing token")
 	}
@@ -190,7 +190,7 @@ func (d *JwtDecoder) useCorrectPublicKey(token *jwt.Token) (publicKey, error) { 
 	return nil, errors.Errorf("failed to decode: no matching key_id (kid) header for: %s", kid)
 }
 
-func (d *JwtDecoder) loadJWKSet() (jwk.Set, error) { //nolint:ireturn
+func (d *JwtDecoder) loadJWKSet() (jwk.Set, error) {
 	// First check cache, if its there then great, use it!
 	if jwks, ok := d.getCachedJWKSet(); ok {
 		return jwks, nil
@@ -219,7 +219,7 @@ func (d *JwtDecoder) loadJWKSet() (jwk.Set, error) { //nolint:ireturn
 	return jwkSet, err
 }
 
-func (d *JwtDecoder) getCachedJWKSet() (jwk.Set, bool) { //nolint:ireturn
+func (d *JwtDecoder) getCachedJWKSet() (jwk.Set, bool) {
 	obj, found := d.cache.Get(jwksCacheKey)
 	if !found {
 		return nil, false
@@ -229,7 +229,7 @@ func (d *JwtDecoder) getCachedJWKSet() (jwk.Set, bool) { //nolint:ireturn
 	return jwks, ok
 }
 
-func (d *JwtDecoder) parseJWKs(jwks string) (jwk.Set, error) { //nolint:ireturn
+func (d *JwtDecoder) parseJWKs(jwks string) (jwk.Set, error) {
 	if jwks == "" {
 		// If no jwks json, then returm empty map
 		return nil, errors.Errorf("missing jwks")

--- a/jwt/decoder_options.go
+++ b/jwt/decoder_options.go
@@ -18,3 +18,42 @@ func WithDecoderCacheExpiry(defaultExpiration, cleanupInterval time.Duration) Jw
 		decoder.cleanupInterval = cleanupInterval
 	}
 }
+
+type DecoderParserOption func(*decoderParser)
+
+type decoderParser struct {
+	expectedAud string
+	expectedIss string
+	expectedSub string
+}
+
+func newDecoderParser() *decoderParser {
+	return &decoderParser{}
+}
+
+// MustMatchAudience configures the validator to require the specified audience in
+// the `aud` claim. Validation will fail if the audience is not listed in the
+// token or the `aud` claim is missing.
+func MustMatchAudience(aud string) DecoderParserOption {
+	return func(p *decoderParser) {
+		p.expectedAud = aud
+	}
+}
+
+// MustMatchIssuer configures the validator to require the specified issuer in the
+// `iss` claim. Validation will fail if a different issuer is specified in the
+// token or the `iss` claim is missing.
+func MustMatchIssuer(iss string) DecoderParserOption {
+	return func(p *decoderParser) {
+		p.expectedIss = iss
+	}
+}
+
+// MustMatchSubject configures the validator to require the specified subject in the
+// `sub` claim. Validation will fail if a different subject is specified in the
+// token or the `sub` claim is missing.
+func MustMatchSubject(sub string) DecoderParserOption {
+	return func(p *decoderParser) {
+		p.expectedSub = sub
+	}
+}

--- a/jwt/decoder_options.go
+++ b/jwt/decoder_options.go
@@ -4,7 +4,7 @@ import (
 	"time"
 )
 
-// JwtDecoderOption function signature for added JWT Decoder options.
+// JwtDecoderOption function signature for adding JWT Decoder options.
 type JwtDecoderOption func(*JwtDecoder)
 
 // WithDecoderCacheExpiry sets the JwtDecoder JWKs cache expiry time.
@@ -19,6 +19,7 @@ func WithDecoderCacheExpiry(defaultExpiration, cleanupInterval time.Duration) Jw
 	}
 }
 
+// DecoderParserOption function signature for adding JWT Decoder Parsing options.
 type DecoderParserOption func(*decoderParser)
 
 type decoderParser struct {
@@ -31,7 +32,7 @@ func newDecoderParser() *decoderParser {
 	return &decoderParser{}
 }
 
-// MustMatchAudience configures the validator to require the specified audience in
+// MustMatchAudience configures the jwt parser to require the specified audience in
 // the `aud` claim. Validation will fail if the audience is not listed in the
 // token or the `aud` claim is missing.
 func MustMatchAudience(aud string) DecoderParserOption {
@@ -40,7 +41,7 @@ func MustMatchAudience(aud string) DecoderParserOption {
 	}
 }
 
-// MustMatchIssuer configures the validator to require the specified issuer in the
+// MustMatchIssuer configures the jwt parser to require the specified issuer in the
 // `iss` claim. Validation will fail if a different issuer is specified in the
 // token or the `iss` claim is missing.
 func MustMatchIssuer(iss string) DecoderParserOption {
@@ -49,7 +50,7 @@ func MustMatchIssuer(iss string) DecoderParserOption {
 	}
 }
 
-// MustMatchSubject configures the validator to require the specified subject in the
+// MustMatchSubject configures the jwt parser to require the specified subject in the
 // `sub` claim. Validation will fail if a different subject is specified in the
 // token or the `sub` claim is missing.
 func MustMatchSubject(sub string) DecoderParserOption {

--- a/jwt/decoder_options_test.go
+++ b/jwt/decoder_options_test.go
@@ -15,7 +15,7 @@ func TestDecoderOptions(t *testing.T) {
 	validJwks := string(b)
 
 	i := 0
-// This will be called each time the cache is refreshed and they we can assert i has been incremented the correct number of times below.
+	// This will be called each time the cache is refreshed and they we can assert i has been incremented the correct number of times below.
 	jwks := func() string {
 		i++
 		return validJwks
@@ -34,4 +34,55 @@ func TestDecoderOptions(t *testing.T) {
 	}
 
 	assert.Greater(t, i, 1)
+}
+
+func TestDecoderParsingOptions(t *testing.T) {
+	token := "eyJhbGciOiJSUzUxMiIsImtpZCI6InJzYS01MTIiLCJ0eXAiOiJKV1QifQ.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiZW5jb2Rlci1uYW1lIiwic3ViIjoidGVzdCIsImF1ZCI6WyJkZWNvZGVyLW5hbWUiXSwiZXhwIjoyMjExNzk3NTMyLCJuYmYiOjE1ODA2MDg5MjIsImlhdCI6MTU4MDYwODkyMn0.hQLuOe8qZHUgstYe0A0n4-Pww7ovlReyKiDR1Y02ltUnUlgbm9qpp-Ef6YNFuIKdHmS-ynQbDx5pbI36szsggzi80apNpI48cwSXshx82TwuU-_Z4wNBXu7MdPvbA5FdjhxCvRqaqhglsGJ6NofC1bP9awVyyy4j9LGfkVuVEXJQrVpdvEs8Ks-LxlWz7_9Cr7BrZcLuBJnujhe4CbdSudkrfeFl19EY3i1wH9OatGjfjwOSJVqv-ZLnn3QkaZmrQ1xwXTm3MlMUH3KSQjBn8h6vbqosIB5iHDFtqR11mLCgYExGHBpzFjM1d5NEmcTNLV9MtZ_qDZwG0wkgv9O4rXVQ0JfdXypMwhchED2Z45_mc2OiLidtKtDmeoE5g0Daq8YpM0ZpVRbXUFeYIZ1doQKUNsbWNdITmrjVOC3Zn8BecYPu1pC4Hk1y-ViArDzxlCMHA7Bua64BfzVuaJ8pBTEmbqMiZ9VujWcimCOtJ5yfCks_RPAhFYOErcqy3B56fmyYdIN__mKl7VvRDtBSiiPGCq07BUjGywaMoZIULbyXYSV4zs3hX_R4_o4asGiVWCZgn7k4pZzCJo_y2e-Mf85nYoRlyr1MXx7IM4srFQCgO-KTjDWL_TXqpMJU5zDzKyelrMFkc6EaMQ2KP_yBhOrh4UW-Pm7ghusox_-bV1U"
+
+	b, err := os.ReadFile(filepath.Clean(testAuthJwks))
+	assert.Nil(t, err)
+	validJwks := string(b)
+
+	jwks := func() string {
+		return validJwks
+	}
+
+	decoder, err := NewJwtDecoder(jwks)
+	assert.Nil(t, err)
+	assert.NotNil(t, decoder)
+
+	// Decode with no MustMatch parsing options
+	claim, err := decoder.Decode(token)
+	assert.Nil(t, err)
+	assert.NotNil(t, claim)
+
+	// Mis-Matched aud claim returns error on Decode
+	claim, err = decoder.Decode(token, MustMatchAudience("abc"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid audience")
+
+	// Matched aud claim returns success
+	claim, err = decoder.Decode(token, MustMatchAudience("decoder-name"))
+	assert.Nil(t, err)
+	assert.NotNil(t, claim)
+
+	// Mis-Matched iss claim returns error on Decode
+	claim, err = decoder.Decode(token, MustMatchIssuer("abc"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid issuer")
+
+	// Matched iss claim returns success
+	claim, err = decoder.Decode(token, MustMatchIssuer("encoder-name"))
+	assert.Nil(t, err)
+	assert.NotNil(t, claim)
+
+	// Mis-Matched sub claim returns error on Decode
+	claim, err = decoder.Decode(token, MustMatchSubject("abc"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid subject")
+
+	// Matched sub claim returns success
+	claim, err = decoder.Decode(token, MustMatchSubject("test"))
+	assert.Nil(t, err)
+	assert.NotNil(t, claim)
 }

--- a/jwt/jwt_example_test.go
+++ b/jwt/jwt_example_test.go
@@ -113,7 +113,7 @@ func ExampleDefaultJwtDecoder() {
 	}
 
 	mockEncDec := newMockedEncoderDecoder()
-	mockEncDec.On("Decode", mock.Anything).Return(claims, nil)
+	mockEncDec.On("Decode", mock.Anything, mock.Anything).Return(claims, nil)
 
 	// Overwrite the Default package level encoder and decoder
 	oldDecoder := jwt.DefaultJwtDecoder
@@ -156,13 +156,13 @@ func (m *mockedEncoderDecoder) EncodeWithCustomClaims(customClaims gojwt.Claims)
 	return output, args.Error(1)
 }
 
-func (m *mockedEncoderDecoder) Decode(tokenString string) (*jwt.StandardClaims, error) {
-	args := m.Called(tokenString)
+func (m *mockedEncoderDecoder) Decode(tokenString string, options ...jwt.DecoderParserOption) (*jwt.StandardClaims, error) {
+	args := m.Called(tokenString, options)
 	output, _ := args.Get(0).(*jwt.StandardClaims)
 	return output, args.Error(1)
 }
 
-func (m *mockedEncoderDecoder) DecodeWithCustomClaims(tokenString string, customClaims gojwt.Claims) error {
-	args := m.Called(tokenString, customClaims)
+func (m *mockedEncoderDecoder) DecodeWithCustomClaims(tokenString string, customClaims gojwt.Claims, options ...jwt.DecoderParserOption) error {
+	args := m.Called(tokenString, customClaims, options)
 	return args.Error(0)
 }

--- a/jwt/package.go
+++ b/jwt/package.go
@@ -15,8 +15,8 @@ type Encoder interface {
 
 // Decoder interface allows for mocking of the Decoder.
 type Decoder interface {
-	Decode(tokenString string) (*StandardClaims, error)
-	DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error
+	Decode(tokenString string, options ...DecoderParserOption) (*StandardClaims, error)
+	DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims, options ...DecoderParserOption) error
 }
 
 var (
@@ -29,21 +29,21 @@ var (
 )
 
 // Decode a jwt token string and return the Standard Culture Amp Claims.
-func Decode(tokenString string) (*StandardClaims, error) {
+func Decode(tokenString string, options ...DecoderParserOption) (*StandardClaims, error) {
 	err := mustHaveDefaultJwtDecoder()
 	if err != nil {
 		return nil, err
 	}
-	return DefaultJwtDecoder.Decode(tokenString)
+	return DefaultJwtDecoder.Decode(tokenString, options...)
 }
 
 // DecodeWithCustomClaims takes a jwt token string and populate the customClaims.
-func DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims) error {
+func DecodeWithCustomClaims(tokenString string, customClaims jwt.Claims, options ...DecoderParserOption) error {
 	err := mustHaveDefaultJwtDecoder()
 	if err != nil {
 		return err
 	}
-	return DefaultJwtDecoder.DecodeWithCustomClaims(tokenString, customClaims)
+	return DefaultJwtDecoder.DecodeWithCustomClaims(tokenString, customClaims, options...)
 }
 
 // Encode the Standard Culture Amp Claims in a jwt token string.

--- a/jwt/package_test.go
+++ b/jwt/package_test.go
@@ -38,6 +38,30 @@ func TestPackageEncodeDecode(t *testing.T) {
 	assert.Equal(t, "abc123", sc.AccountId)
 	assert.Equal(t, "xyz234", sc.RealUserId)
 	assert.Equal(t, "xyz345", sc.EffectiveUserId)
+
+	// Decode it back again, checking aud, iss and sub all match
+	sc, err = Decode(token, MustMatchAudience("decoder-name"), MustMatchIssuer("encoder-name"), MustMatchSubject("test"))
+	assert.Nil(t, err)
+
+	// check it matches
+	assert.Equal(t, "abc123", sc.AccountId)
+	assert.Equal(t, "xyz234", sc.RealUserId)
+	assert.Equal(t, "xyz345", sc.EffectiveUserId)
+
+	// Decode it back again, checking aud should fail
+	sc, err = Decode(token, MustMatchAudience("incorrect-aud"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid audience")
+
+	// Decode it back again, checking iss should fail
+	sc, err = Decode(token, MustMatchIssuer("incorrect-iss"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid issuer")
+
+	// Decode it back again, checking sub should fail
+	sc, err = Decode(token, MustMatchSubject("incorrect-sub"))
+	assert.NotNil(t, err)
+	assert.ErrorContains(t, err, "token has invalid subject")
 }
 
 func TestPackageEncodeDecodeNotBeforeExpiryChecks(t *testing.T) {


### PR DESCRIPTION
Purpose: Allow clients to enforce matching aud, iss and sub claims

Changes:
- created DecoderParserOptions with MustMatchAudience, MustMatchIssuer and MustMatchSubject methods
- updated jwt/README.md