### PR TITLE
Package JWT: Support current Decode behaviour for missing kid in the token

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -174,14 +174,18 @@ issues:
 
   exclude-rules:
     # exluded rules from standard packages for reasons...
-    - path: log/logger.go
-      linters:
-        - zerologlint
-
     - path: log/legacy_extensions.go
       linters:
         - lll
         - tagliatelle
+
+    - path: log/logger.go
+      linters:
+        - zerologlint
+
+    - path: log/fields.go
+      linters:
+        - canonicalheader
 
     - path: jwt/decoder.go
       linters:

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -111,6 +111,12 @@ To do this you can pass `MustMatch<Type>` to the `Decode` and `DecodeWithCustomC
 - func MustMatchIssuer(iss string)
 - func MustMatchSubject(sub string)
 
+### Issues: Decode when missing "kid" header in token
+
+Currently, the web-gateway does NOT add any kid into the tokens is creates. This is because of historical reasons.
+Until all receivers are using the JWKS (which has the web-gateway key with the correct kid) we need to support
+the decode logic of "if no kid, then assume kid="web-gateway"
+
 ## Examples
 ```
 package cago

--- a/jwt/README.md
+++ b/jwt/README.md
@@ -115,7 +115,7 @@ To do this you can pass `MustMatch<Type>` to the `Decode` and `DecodeWithCustomC
 
 Currently, the web-gateway does NOT add any kid into the tokens is creates. This is because of historical reasons.
 Until all receivers are using the JWKS (which has the web-gateway key with the correct kid) we need to support
-the decode logic of "if no kid, then assume kid="web-gateway"
+the decode logic of "if no kid, then assume kid="web-gateway" or we run the risk of breaking legacy receiver code.
 
 ## Examples
 ```

--- a/jwt/decoder.go
+++ b/jwt/decoder.go
@@ -11,6 +11,7 @@ import (
 )
 
 const (
+	webgatewayKid                  = "web-gateway"
 	kidHeaderKey                   = "kid"
 	algorithmHeaderKey             = "alg"
 	accountIDClaim                 = "accountId"
@@ -146,7 +147,11 @@ func (d *JwtDecoder) useCorrectPublicKey(token *jwt.Token) (publicKey, error) {
 	kidHeader, found := token.Header[kidHeaderKey]
 	if !found {
 		// no kid header but its MANDATORY
-		return nil, errors.Errorf("failed to decode: missing key_id (kid) header")
+		// Currently, the web-gateway doesn't encode the "kid" in its tokens (we should fix that)
+		// So until we do, instead of returning an error here, we default to trying the "web-gateway" kid in the JWKs.
+
+		kidHeader = webgatewayKid
+		// return nil, errors.Errorf("failed to decode: missing key_id (kid) header")
 	}
 
 	kid, ok := kidHeader.(string)

--- a/jwt/decoder_test.go
+++ b/jwt/decoder_test.go
@@ -117,9 +117,10 @@ func TestDecoderDecodeAllClaims(t *testing.T) {
 			year:            1,
 		},
 		{
-			desc:            "Error 2: missing kid",
-			token:           "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiY2EtZ28vand0Iiwic3ViIjoic3RhbmRhcmQiLCJleHAiOjIyMTE3OTc1MzIsIm5iZiI6MTU4MDYwODkyMiwiaWF0IjoxNTgwNjA4OTIyfQ.S48Yfs0COCQR70jCrD2y6kD26nns6-c9CLvxKTahxzv0KrkdAXC7I62yIz2yD6j3v3rTKVQ8eGhSKOkN6EU_M8BZa5ltt7TmcIOnn5RWbwnfSfFLMR3njzlMiRT2MGAi2A2WMkx_LrTk9PZZRIlfceQxFVhThjc-Dp92C_zFJARZ8yss3upAW0m0pbeD5Y23GWs6bkkBbAAvh8Rw6rICjW6qROnqj6u8mcb4bS3kDlmmFkYnQdKMLu4bWa6twyLwUMg0N-Y5h2rp6GyAYuTrqyKif5IU1IEhNW63gj5h1xCLNyX4ZGJsNSZP_HOQGVVQMBDg2rsg7tBxow_E2wvYTgDYn8f1SjKE7vKdL2uYzA732hcd63fNwJpNcrwFs3lW8DjM_VYf-M4ePSr4GqHg6PawTCFgWCVNvi-lsmogfRUq_1t21GXlX7pQd029CFJ7mnnxUBau7KxTuX-Pxpny3jhYpJ87GlDA3WaB0r1tEg4Hl87VDawQ5Cb5ac6R6eXEO34i5oESVt6lFL-wpWUnU7KbiWVxKkSifN0M27IE8vAEsUBhgD8sKZpBsUvUDpRcb_atpFE_xU0K6DZXGUgFpZBx-CULmmfoDubTNfRNtqwmJiXI-M1YyiRbc_lOVQBAibuZ20ucixyhhqYSa-5fWa4m5NcjkRquTR2J-OaxmhA",
-			expectedErrMsg:  "missing key_id (kid) header",
+			desc:  "Error 2: missing kid", // note until we encode the web-gateway kid, this will assume kid="web-gateway"
+			token: "eyJhbGciOiJSUzUxMiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50SWQiOiJhYmMxMjMiLCJlZmZlY3RpdmVVc2VySWQiOiJ4eXozNDUiLCJyZWFsVXNlcklkIjoieHl6MjM0IiwiaXNzIjoiY2EtZ28vand0Iiwic3ViIjoic3RhbmRhcmQiLCJleHAiOjIyMTE3OTc1MzIsIm5iZiI6MTU4MDYwODkyMiwiaWF0IjoxNTgwNjA4OTIyfQ.S48Yfs0COCQR70jCrD2y6kD26nns6-c9CLvxKTahxzv0KrkdAXC7I62yIz2yD6j3v3rTKVQ8eGhSKOkN6EU_M8BZa5ltt7TmcIOnn5RWbwnfSfFLMR3njzlMiRT2MGAi2A2WMkx_LrTk9PZZRIlfceQxFVhThjc-Dp92C_zFJARZ8yss3upAW0m0pbeD5Y23GWs6bkkBbAAvh8Rw6rICjW6qROnqj6u8mcb4bS3kDlmmFkYnQdKMLu4bWa6twyLwUMg0N-Y5h2rp6GyAYuTrqyKif5IU1IEhNW63gj5h1xCLNyX4ZGJsNSZP_HOQGVVQMBDg2rsg7tBxow_E2wvYTgDYn8f1SjKE7vKdL2uYzA732hcd63fNwJpNcrwFs3lW8DjM_VYf-M4ePSr4GqHg6PawTCFgWCVNvi-lsmogfRUq_1t21GXlX7pQd029CFJ7mnnxUBau7KxTuX-Pxpny3jhYpJ87GlDA3WaB0r1tEg4Hl87VDawQ5Cb5ac6R6eXEO34i5oESVt6lFL-wpWUnU7KbiWVxKkSifN0M27IE8vAEsUBhgD8sKZpBsUvUDpRcb_atpFE_xU0K6DZXGUgFpZBx-CULmmfoDubTNfRNtqwmJiXI-M1YyiRbc_lOVQBAibuZ20ucixyhhqYSa-5fWa4m5NcjkRquTR2J-OaxmhA",
+			// expectedErrMsg:  "missing key_id (kid) header",
+			expectedErrMsg:  "token signature is invalid",
 			accountId:       "",
 			realUserId:      "",
 			effectiveUserId: "",


### PR DESCRIPTION
Purpose: Support the current Decode behaviour for decoding tokens without a "kid" to mean "web-gateway"

Changes:
- Updated Decoder.go to assume kid="web-gateway" if there is no kid in the token.
- Updated tests
- Updated README to explain what happens where there is no "kid" header in the token.