### PR TITLE
Upgrade to Go 1.22.4

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: 1.22
-  GOTOOLCHAIN: go1.22.3
+  GOTOOLCHAIN: go1.22.4
 
 jobs:
   go-setup:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-golang 1.22.3
+golang 1.22.4

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cultureamp/ca-go
 
-go 1.22.3
+go 1.22.4
 
 require (
 	github.com/aws/aws-lambda-go v1.47.0


### PR DESCRIPTION
From https://go.dev/doc/devel/release:
- go1.22.4 (released 2024-06-04) includes security fixes to the archive/zip and net/netip packages, as well as bug fixes to the compiler, the go command, the linker, the runtime, and the os package. 
- See the [Go 1.22.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.22.4+label%3ACherryPickApproved) on our issue tracker for details.