### PR TITLE
add devbox

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,9 +1,0 @@
-FROM golang:1.22
-
-RUN apt update && apt install -y
-
-# Language autocomplete features.
-RUN go install golang.org/x/tools/gopls@latest
-RUN go install golang.org/x/tools/cmd/goimports@latest
-
-CMD /usr/bin/bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,8 +1,0 @@
-{
-	"name": "ca-go",
-    "dockerFile": "./Dockerfile",
-	"extensions": [
-        "golang.go",
-        "ms-vscode.makefile-tools"
-    ]
-}

--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,7 @@
+# Automatically sets up your devbox environment whenever you cd into this
+# directory via our direnv integration:
+
+eval "$(devbox generate direnv --print-envrc)"
+
+# check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
+# for more details

--- a/.envrc
+++ b/.envrc
@@ -5,3 +5,8 @@ eval "$(devbox generate direnv --print-envrc)"
 
 # check out https://www.jetpack.io/devbox/docs/ide_configuration/direnv/
 # for more details
+
+# Add any environment variable customisations that you wish to keep out of version control to
+# to .env.local instead.
+# https://github.com/direnv/direnv/issues/348#issuecomment-588487223
+[ -f ".env.local" ] && dotenv ".env.local"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .DS_Store
 /.idea
 .dccache
+.env.local
 
 # Binaries for programs and plugins
 *.exe

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 /artifacts
 .DS_Store
 /.idea
-.envrc
 .dccache
 
 # Binaries for programs and plugins

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ repos:
     rev: v4.5.0 # Use the ref you want to point at
     hooks:
       - id: check-json
+        exclude: 'devbox.json' # Is HuJSON which allows comments and trailing commas. https://github.com/tailscale/hujson
       - id: check-yaml
       - id: check-added-large-files
         args: [--maxkb=100]

--- a/README.md
+++ b/README.md
@@ -37,35 +37,20 @@ These packages are going to be changed in the near future.
 
 ## Contributing
 
-To work on `ca-go`, you'll need a working Go installation. The project currently targets Go 1.22.
+### Installation and running with Devbox
 
-### Setting up your environment
+Ensure devbox is setup as per [https://cultureamp.atlassian.net/wiki/spaces/DE/pages/3342434338/Devbox+setup](https://cultureamp.atlassian.net/wiki/spaces/DE/pages/3342434338/Devbox+setup)
 
-You can use [VSCode Remote Containers](https://code.visualstudio.com/docs/remote/containers) to get
-up-and-running quickly. A basic configuration is defined in the `.devcontainer/`
-directory. This works locally and via [GitHub Codespaces](https://github.com/features/codespaces).
-
-#### Locally
-
-1. Clone `ca-go` and open the directory in VSCode.
-2. A prompt should appear on the bottom-right of the editor, offering to start a Remote Containers session. Click **Reopen in Container**.
-3. If a prompt didn't appear, open the Command Palette (i.e. Cmd + Shift + P) and select **Remote-Containers: Open Folder in Container...**
-
-#### Codespaces
-
-1. Click the **Code** button above the source listing on the repository homepage.
-2. Click **New codespace**.
+Run
+```
+devbox run setup
+```
 
 ### Pre-Commit
 
 This is optional but is recommended for engineers working with highly sensitive secrets or data.
 
 The pre-commit config is stored in `.pre-commit-config.yaml`.
-
-Download:
-1. brew install pre-commit
-2. brew install trufflehog
-3. brew install snyk-cli
 
 To install / turn on for a repo:
 %> pre-commit install

--- a/devbox.json
+++ b/devbox.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.11.0/.schema/devbox.schema.json",
+  "packages": [
+    "go@1.22",
+    "pre-commit@latest",
+    "snyk@latest",
+    "trufflehog@latest",
+  ],
+  "shell": {
+    "scripts": {
+      "setup": "make mod"
+    },
+  },
+}

--- a/devbox.json
+++ b/devbox.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/jetify-com/devbox/0.11.0/.schema/devbox.schema.json",
   "packages": [
-    "go@1.22",
+    "go@1.22", // go 1.22.4 at nixhub.io/packages/go yet. Update to go@1.22.4 when it becomes available.
     "pre-commit@latest",
     "snyk@latest",
     "trufflehog@latest",

--- a/devbox.json
+++ b/devbox.json
@@ -8,7 +8,7 @@
   ],
   "shell": {
     "scripts": {
-      "setup": "make mod"
+      "setup": "make mod",
     },
   },
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -48,6 +48,166 @@
           "store_path": "/nix/store/00mg4vlhzmm7gi9bd5v5ydjlgrywpc3n-go-1.22.3"
         }
       }
+    },
+    "pre-commit@latest": {
+      "last_modified": "2024-05-26T09:30:02Z",
+      "resolved": "github:NixOS/nixpkgs/e2dd4e18cc1c7314e24154331bae07df76eb582f#pre-commit",
+      "source": "devbox-search",
+      "version": "3.7.1",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/hdqk1313v33fw1nqh7nsx1bn1b3f29ml-pre-commit-3.7.1",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/shg03vyd44p9mmn4hdavxxw2dfhm3k3v-pre-commit-3.7.1-dist"
+            }
+          ],
+          "store_path": "/nix/store/hdqk1313v33fw1nqh7nsx1bn1b3f29ml-pre-commit-3.7.1"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/xn6p604n92y45q6pdwz0a0y8fvyx5n7l-pre-commit-3.7.1",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/cqma4gps1mymzfvy2lph3dpijzwkzi2a-pre-commit-3.7.1-dist"
+            }
+          ],
+          "store_path": "/nix/store/xn6p604n92y45q6pdwz0a0y8fvyx5n7l-pre-commit-3.7.1"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nrmv6m5065d8l7805hdr3yz6lwkr3842-pre-commit-3.7.1",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/f2j9cxgdm2sj50rq8l8z56nvavrw4z8v-pre-commit-3.7.1-dist"
+            }
+          ],
+          "store_path": "/nix/store/nrmv6m5065d8l7805hdr3yz6lwkr3842-pre-commit-3.7.1"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/f8pinfigkavdvdaa9ngxk2pgaiz713bl-pre-commit-3.7.1",
+              "default": true
+            },
+            {
+              "name": "dist",
+              "path": "/nix/store/zcmbq6nvak8iq6wp0kji93vyfzgz5y6b-pre-commit-3.7.1-dist"
+            }
+          ],
+          "store_path": "/nix/store/f8pinfigkavdvdaa9ngxk2pgaiz713bl-pre-commit-3.7.1"
+        }
+      }
+    },
+    "snyk@latest": {
+      "last_modified": "2024-05-22T06:18:38Z",
+      "resolved": "github:NixOS/nixpkgs/3f316d2a50699a78afe5e77ca486ad553169061e#snyk",
+      "source": "devbox-search",
+      "version": "1.1291.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/5b1pd3xshrc3rvzipmk2r6swmxaqfla0-snyk-1.1291.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/5b1pd3xshrc3rvzipmk2r6swmxaqfla0-snyk-1.1291.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/9z26b6aialc251ff74qr4y7vxpn7szwd-snyk-1.1291.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/9z26b6aialc251ff74qr4y7vxpn7szwd-snyk-1.1291.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/qsvjajm5q47rb2xz252jl9pnibvgw527-snyk-1.1291.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/qsvjajm5q47rb2xz252jl9pnibvgw527-snyk-1.1291.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/c9ckm8zsak584hjpw7akrmhqrcnx65bx-snyk-1.1291.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/c9ckm8zsak584hjpw7akrmhqrcnx65bx-snyk-1.1291.0"
+        }
+      }
+    },
+    "trufflehog@latest": {
+      "last_modified": "2024-05-29T10:04:41Z",
+      "resolved": "github:NixOS/nixpkgs/ac82a513e55582291805d6f09d35b6d8b60637a1#trufflehog",
+      "source": "devbox-search",
+      "version": "3.77.0",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/87z3pzzjf061zq0z4zngsxmqxil6ixk8-trufflehog-3.77.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/87z3pzzjf061zq0z4zngsxmqxil6ixk8-trufflehog-3.77.0"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/28sflh86psbidbyggjas53lsybps1s4j-trufflehog-3.77.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/28sflh86psbidbyggjas53lsybps1s4j-trufflehog-3.77.0"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/n1qv21m5iancvsxr04nph1k96w1nncm6-trufflehog-3.77.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/n1qv21m5iancvsxr04nph1k96w1nncm6-trufflehog-3.77.0"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/bcsbyb6c6csn3pmms5ynpcq2pdjzv3wk-trufflehog-3.77.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/bcsbyb6c6csn3pmms5ynpcq2pdjzv3wk-trufflehog-3.77.0"
+        }
+      }
     }
   }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -1,0 +1,53 @@
+{
+  "lockfile_version": "1",
+  "packages": {
+    "go@1.22": {
+      "last_modified": "2024-05-29T10:04:41Z",
+      "resolved": "github:NixOS/nixpkgs/ac82a513e55582291805d6f09d35b6d8b60637a1#go",
+      "source": "devbox-search",
+      "version": "1.22.3",
+      "systems": {
+        "aarch64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/i04a1a6qgxhjw6c0ld2b3x1v815sbxjc-go-1.22.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/i04a1a6qgxhjw6c0ld2b3x1v815sbxjc-go-1.22.3"
+        },
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/d68f2iblysnl0r4qcfdacmdpmvvy86kf-go-1.22.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/d68f2iblysnl0r4qcfdacmdpmvvy86kf-go-1.22.3"
+        },
+        "x86_64-darwin": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/1p6vr83cgyfwm8517jhfmf6lypzhy3q2-go-1.22.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/1p6vr83cgyfwm8517jhfmf6lypzhy3q2-go-1.22.3"
+        },
+        "x86_64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/00mg4vlhzmm7gi9bd5v5ydjlgrywpc3n-go-1.22.3",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/00mg4vlhzmm7gi9bd5v5ydjlgrywpc3n-go-1.22.3"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Purpose

Adds devbox as the means for setting up the projects locally.

## Changes

- **Add note about go@1.22.4**
- **Add .env.local to .gitignore and add loading of .env.local to .envrc**
- **Remove .envrc from .gitignore**
- **Run `devbox generate direnv`**
- **Add devbox.json**
- **Devbox add pre-commit, snyk, trufflehog**
- **Exclude devbox.json from check-json commit hook**
- **Update README.md with instructions for setting up with devbox.**
- **Remove .devcontainer config**
- **Remove .tool-versions**

## How to review this PR

 - Check out this branch and review the new [readme instructions](https://github.com/cultureamp/ca-go/tree/add-devbox?tab=readme-ov-file#installation-and-running-with-devbox).
 - After running the `devbox run setup` command ensure that you can develop on the project as expected.

## Considerations

This cleans up other means for setting up the projects i.e. asdf, devcontainers so that there's a single clear way to get up and running.

Devbox installs the requirement for the pre-commit configuration but it's up to individual developers to run `pre-commit install`. I tried adding `pre-commit install` to the automatic setup but that is too invasive because it looks like the snyk cli requires being logged into run.

We don't have a process-compose file working on this project doesn't have any running processes. Instead instructions say to run `devbox run setup` instead of `devbox services up`
